### PR TITLE
Use resource field and remove some exploratory parsing

### DIFF
--- a/plugins/kubernetes.yaml
+++ b/plugins/kubernetes.yaml
@@ -1,3 +1,4 @@
+---
 version: 0.0.6
 title: Kubernetes
 description: Log parser for Kubernetes
@@ -6,7 +7,7 @@ parameters:
     label: Containers Log Path
     description: Kubernetes Containers Log Path
     type: string
-    required: true
+    default: "/var/log/containers/*"
   kubelet_journald_log_path:
     label: Kubelet Journald Log Path
     description: 'Kubernetes Kubelet Journald Log path. It will read from /run/journal or /var/log/journal if this parameter is omitted'
@@ -16,40 +17,29 @@ parameters:
     description: "Start reading file from 'beginning' or 'end'"
     type: enum
     valid_values:
-     - beginning
-     - end
+      - beginning
+      - end
     default: end
+
+# Set Defaults
+# {{ $container_log_path := default "/var/log/containers/*" .container_log_path }}
+# {{ $start_at := default "end" .start_at }}
 
 # Pipeline Template
 pipeline:
-  # {{ if .container_log_path }}
   - id: container_reader
     type: file_input
     include:
-      - {{ .container_log_path }}
-    start_at: {{ or .start_at "end" }}
+      - '{{ $container_log_path }}'
+    start_at: '{{ $start_at }}'
     labels:
-      plugin_id: {{ .id }}
-    include_file_path: true
+      plugin_id: '{{ .id }}'
     write_to: log
 
-  # Filter stanza logs. Check if file_name field starts with stanza. if it does drop the log entry otherwise continue down pipeline
-  - id: filename_router
-    type: router
-    routes:
-      - expr: '$labels.file_name != nil and $labels.file_name matches "^stanza"'
-        output: drop_output
-      - expr: true
-        output: remove_file_name
-
-  # Drop unwanted logs
-  - type: "drop_output"
-
-  # Remove file_name label. We have filtered stanza logs and no longer need the file name
-  - id: remove_file_name
-    type: restructure
-    ops:
-      - remove: $labels.file_name
+  # Filter out agent logs. Check if file_name field starts with stanza or bindplane-agent.
+  - id: filename_filter
+    type: filter
+    expr: '$labels.file_name != nil and ($labels.file_name contains "stanza" or $labels.file_name contains "bindplane-agent")'
 
   # Initial log entry should be safe to parse as JSON
   - id: container_json_parser
@@ -60,31 +50,12 @@ pipeline:
   - id: log_json_router
     type: router
     routes:
-      # If there is no log field under record bypass json parser
-      - output: container_regex_parser
-        expr: '$record.log == nil'
-      # If log field is JSON with trailing newline route to regex_parser to remove newline before parsing.
-      - output: remove_new_line
-        expr: $record.log matches '^{.*}\\n$'
       # It appears to be JSON so send it to be parsed as JSON.
       - output: nested_json_parser
-        expr: $record.log matches '^{.*}$'
+        expr: '$record.log != nil and $record.log matches "^{.*}\\s*$"'
       # If log field doesn't appear to be JSON then, skip nested JSON parsers
       - output: container_regex_parser
         expr: true
-
-  # Remove new line from end of jsonUnable to parse json if it has a newline.
-  - id: remove_new_line
-    type: regex_parser
-    parse_from: $record.log
-    regex: '(?P<log_tmp>{.*})\s+'
-    output: nested_tmp_json_parser
-
-  # We now have removed newline and saved log field to log_tmp
-  - id: nested_tmp_json_parser
-    type: json_parser
-    parse_from: $record.log_tmp
-    output: container_regex_parser
 
   # Use this JSON parser since there was no trailing newline in log field.
   - id: nested_json_parser
@@ -95,8 +66,8 @@ pipeline:
   # Log field has been parsed if possible and now we can parse log_type field for container information.
   - id: container_regex_parser
     type: regex_parser
-    parse_from: $labels.file_path
-    regex: '\/var\/log\/containers\/(?P<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?P<namespace>[^_]+)_(?P<container_name>.+)-(?P<container_id>[a-z0-9]{64})\.log'
+    parse_from: $labels.file_name
+    regex: '^(?P<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?P<namespace>[^_]+)_(?P<container_name>.+)-(?P<container_id>[a-z0-9]{64})\.log$'
     severity:
       parse_from: stream
       preserve: true
@@ -107,46 +78,21 @@ pipeline:
       parse_from: time
       layout: '%Y-%m-%dT%H:%M:%S.%sZ'
 
-  # Check if there is a timestamp field in record and if it is in expected format. If so parse it otherwise continue down pipeline.
-  - id: timestamp_parser_router
-    type: router
-    routes:
-      - output: timestamp_parser
-        expr: '$record.timestamp != nil and $record.timestamp matches "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d+Z"'
-      - output: standard_regex_parser_router
-        expr: true
-
-  # Parse timestamp field in record.
-  - id: timestamp_parser
-    type: time_parser
-    parse_from: timestamp
-    layout: '%Y-%m-%dT%H:%M:%S.%sZ'
-
-  # Check if log field exists and if it matches format. If so parse it otherwise continue down the pipeline
-  - id: standard_regex_parser_router
-    type: router
-    routes:
-      - output: standard_regex_parser
-        expr: '$record.log != nil and $record.log matches "^\\w\\d{4}"'
-      - output: add_kubernetes_metadata
-        expr: true
-
-  # Log field exists and matches expected format.
-  - id: standard_regex_parser
-    type: regex_parser
-    parse_from: log
-    regex: '(?P<severity>\w)(?P<timestamp>\d{4} \d{2}:\d{2}:\d{2}.\d+)\s+(?P<pid>\d+)\s+(?P<source>[^ \]]+)\] (?P<message>.*)'
-    severity:
-      parse_from: severity
-      mapping:
-        debug: d
-        info: i
-        warning: w
-        error: e
-        critical: c
-    timestamp:
-      parse_from: timestamp
-      layout: '%m%d %H:%M:%S.%s'
+  - id: resource_restructurer
+    type: restructure
+    ops:
+      - move:
+          from: '$record.pod_name'
+          to: '$resource["k8s.pod.name"]'
+      - move:
+          from: '$record.namespace'
+          to: '$resource["k8s.namespace.name"]'
+      - move:
+          from: '$record.container_name'
+          to: '$resource["container.name"]'
+      - move:
+          from: '$record.container_id'
+          to: '$resource["container.id"]'
 
   # Add kubernetes metadata
   - id: add_kubernetes_metadata
@@ -177,25 +123,22 @@ pipeline:
         expr: true
         labels:
           log_type: 'k8s.container'
-  # {{ end }}
 
   # Use journald to gather kubelet logs. Use provider path for journald if available otherwise use default locations.
   - id: kubelet_reader
     type: journald_input
     # {{ if .kubelet_journald_log_path }}
-    directory: {{ .kubelet_journald_log_path }}
+    directory: '{{ .kubelet_journald_log_path }}'
     # {{ end }}
     labels:
       log_type: 'k8s.kubelet'
-      plugin_id: {{ .id }}
-    output: kubelet_filter_router
+      plugin_id: '{{ .id }}'
+    output: kubelet_filter
 
-  # Only grab entry if it is the kubelet.server
-  - id: kubelet_filter_router
-    type: router
-    routes:
-      - output: kubelet_message_parser_router
-        expr: '$record._SYSTEMD_UNIT == "kubelet.service"'
+  # Only grab entry if it is the kubelet.service
+  - id: kubelet_filter
+    type: filter
+    expr: '$record._SYSTEMD_UNIT != "kubelet.service"'
 
   # If MESSAGE field matches format then, parse it otherwise send down the pipeline.
   - id: kubelet_message_parser_router

--- a/plugins/kubernetes.yaml
+++ b/plugins/kubernetes.yaml
@@ -57,13 +57,13 @@ pipeline:
       - output: container_regex_parser
         expr: true
 
-  # Use this JSON parser since there was no trailing newline in log field.
+  # Attempt to parse nested JSON since the log appears to be JSON
   - id: nested_json_parser
     type: json_parser
     parse_from: $record.log
     output: container_regex_parser
 
-  # Log field has been parsed if possible and now we can parse log_type field for container information.
+  # Log field has been parsed if possible and now we can parse the file name field for container information.
   - id: container_regex_parser
     type: regex_parser
     parse_from: $labels.file_name
@@ -124,7 +124,7 @@ pipeline:
         labels:
           log_type: 'k8s.container'
 
-  # Use journald to gather kubelet logs. Use provider path for journald if available otherwise use default locations.
+  # Use journald to gather kubelet logs. Use provided path for journald if available otherwise use default locations.
   - id: kubelet_reader
     type: journald_input
     # {{ if .kubelet_journald_log_path }}


### PR DESCRIPTION
- Uses `default` in templates
- Fixes YAML formatting issues
- Removes `file_path` and just parses from `file_name`
- Uses new filter plugin rather than router
- Filters out `bindplane-agent` logs in addition to just `stanza`
- Removes newline logic because I was unable to reproduce the original issue, and it's a bug in the parser if it does still exist, and should be fixed there rather than in the plugins
- Removes exploratory parsing of application-specific logs that was causing parsing errors for logs that look similar
- Adds container information to resource