### PR TITLE
Update defaults Windows DHCP and plugins with udp and tcp_input

### DIFF
--- a/plugins/cisco_asa.yaml
+++ b/plugins/cisco_asa.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: Cisco ASA
 description: Log parser for Cisco ASA
 parameters:
@@ -7,10 +7,10 @@ parameters:
     label: Listen Address
     description: A syslog address of the form `<ip>:<port>`
     type: string
-    default: ":5140"
+    default: "0.0.0.0:5140"
 
 # Set Defaults
-{{$listen_address := default ":5140" .listen_address}}
+# {{$listen_address := default "0.0.0.0:5140" .listen_address}}
 
 # Pipeline Template
 pipeline:

--- a/plugins/cisco_meraki.yaml
+++ b/plugins/cisco_meraki.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: Cisco Meraki
 description: Log parser for Cisco Meraki
 parameters:
@@ -7,10 +7,10 @@ parameters:
     label: Listen Address
     description: A syslog address of the form `<ip>:<port>`
     type: string
-    default: ":5140"
+    default: "0.0.0.0:5140"
 
 # Set Defaults
-{{$listen_address := default ":5140" .listen_address}}
+# {{$listen_address := default "0.0.0.0:5140" .listen_address}}
 
 # Pipeline Template
 pipeline:

--- a/plugins/syslog.yaml
+++ b/plugins/syslog.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: Syslog
 description: Log parser for Syslog
 parameters:
@@ -26,13 +26,13 @@ parameters:
     default: rfc5424
 
 # Set Defaults
-{{$listen_address := default ":514" .listen_address}}
-{{$connection_type := default "udp" .connection_type}}
-{{$protocol := default "rfc5424" .protocol}}
+# {{$listen_address := default "0.0.0.0:514" .listen_address}}
+# {{$connection_type := default "udp" .connection_type}}
+# {{$protocol := default "rfc5424" .protocol}}
 
 # Pipeline Template
 pipeline:
-{{ if eq $connection_type "udp" }}
+# {{ if eq $connection_type "udp" }}
   - id: syslog_input
     type: udp_input
     listen_address: {{ $listen_address }}
@@ -40,9 +40,9 @@ pipeline:
       log_type: syslog
       plugin_id: {{ .id }}
     output: syslog_parser
-{{ end }}
+# {{ end }}
 
-{{ if eq $connection_type "tcp" }}
+# {{ if eq $connection_type "tcp" }}
   - id: syslog_input
     type: tcp_input
     listen_address: {{ $listen_address }}
@@ -50,7 +50,7 @@ pipeline:
       log_type: syslog
       plugin_id: {{ .id }}
     output: syslog_parser
-{{ end }}
+# {{ end }}
 
   - id: syslog_parser
     type: syslog_parser

--- a/plugins/vmware_esxi.yaml
+++ b/plugins/vmware_esxi.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: VMware ESXi
 description: Log parser for VMware ESXi
 parameters:
@@ -7,10 +7,10 @@ parameters:
     label: Listen Address
     description: A syslog address of the form `<ip>:<port>`
     type: string
-    default: ":5140"
+    default: "0.0.0.0:5140"
 
 # Set Defaults
-{{$listen_address := default ":5140" .listen_address}}
+# {{$listen_address := default "0.0.0.0:5140" .listen_address}}
 
 # Pipeline Template
 pipeline:

--- a/plugins/vmware_vcenter.yaml
+++ b/plugins/vmware_vcenter.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: VMware vCenter
 description: Log parser for VMware vCenter
 parameters:
@@ -7,10 +7,10 @@ parameters:
     label: Listen Address
     description: A syslog address of the form `<ip>:<port>`
     type: string
-    default: ":5140"
+    default: "0.0.0.0:5140"
 
 # Set Defaults
-{{$listen_address := default ":5140" .listen_address}}
+# {{$listen_address := default "0.0.0.0:5140" .listen_address}}
 
 # Pipeline Template
 pipeline:

--- a/plugins/windows_dhcp.yaml
+++ b/plugins/windows_dhcp.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: Windows DHCP
 description: Log parser for Windows DHCP
 parameters:
@@ -7,7 +7,7 @@ parameters:
     label: Log Path
     description: The absolute path to the DHCP logs
     type: string
-    default: "C:/Windows/System32/dhcp/DhcpSrvLog-*.log"
+    default: 'C:\Windows\System32\dhcp\DhcpSrvLog-*.log'
   start_at:
     label: Start At
     description: Start reading file from 'beginning' or 'end'
@@ -18,8 +18,8 @@ parameters:
     default: end
 
 # Set Defaults
-{{$file_path := default "C:/Windows/System32/dhcp/DhcpSrvLog-*.log" .file_path}}
-{{$start_at := default "end" .start_at}}
+# {{$file_path := default "C:\Windows\System32\dhcp\DhcpSrvLog-*.log" .file_path}}
+# {{$start_at := default "end" .start_at}}
 
 # Pipeline Template
 pipeline:


### PR DESCRIPTION
Update `windows_dhcp` plugin default path to use backslashes
Update the default ip:port on the following plugins
* `cisco_asa`
* `cisco_meraki`
* `syslog`
* `vmware_esxi`
* `vmware_vcenter`
