### PR TITLE
Fix some typos in plugin labels

### DIFF
--- a/plugins/kafka.yaml
+++ b/plugins/kafka.yaml
@@ -13,7 +13,7 @@ parameters:
     type: string
     default: "/home/kafka/kafka/logs/server.log*"
   enable_controller_log:
-    label: Server Logs
+    label: Controller Logs
     description: Enable to collect Apache Kafka controller logs
     type: bool
     default: true
@@ -33,7 +33,7 @@ parameters:
     type: string
     default: "/home/kafka/kafka/logs/state-change.log*"
   enable_log_cleaner_log:
-    label: Server Logs
+    label: Log Cleaner Logs
     description: Enable to collect Apache Kafka log cleaner logs
     type: bool
     default: true
@@ -151,3 +151,4 @@ pipeline:
     parse_from: timestamp
     layout: '%F %T.%L'
     output: {{ .output }}
+

--- a/plugins/tail.yaml
+++ b/plugins/tail.yaml
@@ -14,7 +14,7 @@ parameters:
     type: strings
     default: []
   poll_interval:
-    label: Poll poll_interval
+    label: Poll Interval
     description: The duration between filesystem polls.
     type: string
     default: 200ms
@@ -125,3 +125,4 @@ pipeline:
   - type: json_parser
     output: {{ .output }}
 #{{ end }}
+

--- a/plugins/tail.yaml
+++ b/plugins/tail.yaml
@@ -65,7 +65,7 @@ parameters:
     default: end
   log_type:
     label: Log Type
-    description: Adds label log_type to idently tail source.
+    description: Adds label log_type to identify tail source.
     type: string
     default: tail
   parse_format:

--- a/plugins/tomcat.yaml
+++ b/plugins/tomcat.yaml
@@ -13,7 +13,7 @@ parameters:
     type: string
     default: "/usr/local/tomcat/logs/localhost_access_log.*.txt"
   enable_catalina_log:
-    label: Access Logs
+    label: Catalina Logs
     description: Enable to collect Apache Tomcat catalina logs
     type: bool
     default: true
@@ -90,3 +90,4 @@ pipeline:
           - finest
     output: {{ .output }}
   #{{ end }}
+


### PR DESCRIPTION
There are a couple inconsistencies between parameters being pluralized or not, but decided to just fix these so that they don't persist into the future for right now and shouldn't require version bumps. 