### PR TITLE
Fixed regexp parsing error in error log

### DIFF
--- a/plugins/apache_http.yaml
+++ b/plugins/apache_http.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 title: Apache HTTP Server
 description: Log parser for Apache HTTP Server
 parameters:
@@ -39,8 +39,8 @@ parameters:
 #{{$start_at := default "end" .start_at}}
 
 pipeline:
-  #{{ if $enable_error_log }}
-  - id: htaccess_access_reader
+  #{{ if $enable_access_log }}
+  - id: access_log_reader
     type: file_input
     include:
       - {{ $access_log_path }}
@@ -51,28 +51,28 @@ pipeline:
 
   - id: access_regex_parser
     type: regex_parser
-    regex: '^(?P<remote>[^ ]*) (?P<host>[^ ]*) (?P<user>[^ ]*) \[(?P<time>[^\]]*)\] "(?P<method>\S+)(?: +(?P<path>[^\"]*?)(?: +\S*)?)?" (?P<code>[^ ]*) (?P<size>[^ ]*)(?: "(?P<referer>[^\"]*)" "(?P<agent>[^\"]*)"(?:\s+(?P<http_x_forwarded_for>[^ ]+))?)?$'
+    regex: '^(?P<remote>[^ ]*) (?P<host>[^ ]*) (?P<user>[^ ]*) \[(?P<time>[^\]]*)\] "(?P<method>\S+)(?: +(?P<path>[^\"]*?)(?: +\S*)?)?" (?P<code>[^ ]*) (?P<size>[^ ]*)(?: "(?P<referer>[^\"]*)" "(?P<agent>[^\"]*)"(?:\s+(?P<http_x_forwarded_for>[^ ]+))?)?'
     timestamp:
       parse_from: time
       layout: '%d/%b/%Y:%H:%M:%S %z'
     output: {{ .output }}
   #{{ end }}
 
-  #{{ if $enable_access_log }}
-  - id: htaccess_error_reader
+  #{{ if $enable_error_log }}
+  - id: error_log_reader
     type: file_input
     include:
       - {{ $error_log_path }}
     start_at: {{ $start_at }}
     multiline:
-      line_start_pattern: '\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} \[\w+\] (?P<pid>\d+).(?P<tid>\d+): '
+      line_start_pattern: '\[(?P<time>\w+ \w+ \d{2} \d{2}:\d{2}:\d{2}\.\d+ \d+)\] '
     labels:
       log_type: 'apache_http.error'
       plugin_id: {{ .id }}
 
   - id: error_regex_parser
     type: regex_parser
-    regex: '^\[(?P<time>\w+ \w+ \d{2} \d{2}:\d{2}:\d{2}\.\d+ \d+)\] \[(?P<module>\w+):(?P<log_level>\w+)\] \[pid (?P<pid>\d+):tid (?P<tid>\d+)\] (?P<error_code>[^:]+): (?P<message>.*)'
+    regex: '^\[(?P<time>\w+ \w+ \d{2} \d{2}:\d{2}:\d{2}\.\d+ \d+)\] \[(?P<module>\w+):(?P<log_level>\w+)\] \[pid (?P<pid>\d+)(?::tid (?P<tid>[\d]+))?\](?: \[client (?P<client>[^\]]*)\])? (?P<error_code>[^:]+): (?P<message>.*)'
     timestamp:
       parse_from: time
       layout: '%a %b %d %T.%s %Y'


### PR DESCRIPTION
- Swapped enable error and enable access log to enable the correct log type.
- Fixed issue with multiline: `start_line_pattern` regex.
- Added parsing of `client`  field if present.
- Made tid field optional as it may not be present in logs.
- Renamed file input ID's to be more clear.