### PR TITLE
Specify Platforms For Platform Specific Plugins

### DIFF
--- a/plugins/kubernetes.yaml
+++ b/plugins/kubernetes.yaml
@@ -1,6 +1,8 @@
-version: 0.0.7
+version: 0.0.8
 title: Kubernetes
 description: Log parser for Kubernetes
+supported_platforms: 
+  - kubernetes
 parameters:
   - name: container_log_path
     label: Containers Log Path

--- a/plugins/kubernetes_cluster.yaml
+++ b/plugins/kubernetes_cluster.yaml
@@ -1,6 +1,8 @@
-version: 0.0.7
+version: 0.0.8
 title: Kubernetes
 description: Log parser for Kubernetes
+supported_platforms: 
+  - kubernetes
 parameters:
   - name: container_log_path
     label: Containers Log Path

--- a/plugins/kubernetes_container.yaml
+++ b/plugins/kubernetes_container.yaml
@@ -1,8 +1,10 @@
-version: 0.0.7
+version: 0.0.8
 title: Kubernetes
 id: kubernetes
 description: Log parser for Kubernetes
 min_stanza_version: 0.9.8
+supported_platforms: 
+  - kubernetes
 parameters:
   - name: cluster_name
     label: Cluster Name

--- a/plugins/kubernetes_events.yaml
+++ b/plugins/kubernetes_events.yaml
@@ -1,7 +1,9 @@
 # Plugin Info
-version: 0.0.2
+version: 0.0.3
 title: Kubernetes Events
 description: Kubernetes Events Parser
+supported_platforms: 
+  - kubernetes
 parameters:
   - name: namespaces
     label: Namespaces

--- a/plugins/windows_active_directory.yaml
+++ b/plugins/windows_active_directory.yaml
@@ -1,7 +1,9 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: Microsoft Active Directory
 description: Log parser for Microsoft Active Directory
+supported_platforms: 
+  - windows
 parameters:
   - name: enable_dns_server
     label: Enable DNS Server Events

--- a/plugins/windows_dhcp.yaml
+++ b/plugins/windows_dhcp.yaml
@@ -1,7 +1,9 @@
 # Plugin Info
-version: 0.0.3
+version: 0.0.4
 title: Windows DHCP
 description: Log parser for Windows DHCP
+supported_platforms: 
+  - windows
 parameters:
   - name: file_path
     label: Log Path

--- a/plugins/windows_event.yaml
+++ b/plugins/windows_event.yaml
@@ -1,7 +1,9 @@
 # Plugin Info
-version: 0.0.2
+version: 0.0.3
 title: Windows Event Log
 description: Windows Event Log Parser
+supported_platforms: 
+  - windows
 parameters:
   - name: enable_system_events
     label: System Events


### PR DESCRIPTION
- We will assume that if these are not specified then we would assume a default of ['macos', 'windows', 'linux']
- This specific metadata will help document intended platforms that these plugins are supported for