### PR TITLE
Bug: Hadoop Empty String fixes

### DIFF
--- a/plugins/hadoop.yaml
+++ b/plugins/hadoop.yaml
@@ -90,6 +90,7 @@ parameters:
 # Pipeline Template
 pipeline:
 {{ if $enable_datanode_logs }}
+  {{ if $datanode_general_log_path }}
   - id: hadoop_datanode_general_input
     type: file_input
     include:
@@ -115,7 +116,9 @@ pipeline:
         warning: warn
         critical: fatal
     output: {{.output}}
+  {{ end }}
 
+  {{ if $datanode_yarn_log_path }}
   - id: hadoop_datanode_yarn_input
     type: file_input
     include:
@@ -141,9 +144,11 @@ pipeline:
         warning: warn
         critical: fatal
     output: {{.output}}
+  {{ end }}
 {{ end }}
 
 {{ if $enable_resourcemgr_logs }}
+  {{ if $resourcemgr_general_log_path}}
   - id: hadoop_resourcemgr_general_input
     type: file_input
     include:
@@ -169,7 +174,9 @@ pipeline:
         warning: warn
         critical: fatal
     output: {{.output}}
+  {{ end }}
 
+  {{ if $resourcemgr_yarn_log_path}}
   - id: hadoop_resourcemgr_yarn_input
     type: file_input
     include:
@@ -195,9 +202,11 @@ pipeline:
         warning: warn
         critical: fatal
     output: {{.output}}
+  {{ end }}
 {{ end }}
 
 {{ if $enable_namenode_logs }}
+  {{ if $namenode_general_log_path }}
   - id: hadoop_namenode_general_input
     type: file_input
     include:
@@ -223,7 +232,9 @@ pipeline:
         warning: warn
         critical: fatal
     output: {{.output}}
+  {{ end }}
 
+  {{ if $namenode_yarn_log_path }}
   - id: hadoop_namenode_yarn_input
     type: file_input
     include:
@@ -249,4 +260,5 @@ pipeline:
         warning: warn
         critical: fatal
     output: {{.output}}
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
We are getting these errors when we enable resource manager logs but only supply one of the associated log paths. We can solve this by checking to make sure we are not trying to file_input on empty strings. This gives the plugin the flexibility to enable collection of these logs, while also looking to only collect one of types of logs. 

### Errors
```
{"level":"warn","ts":"2020-11-19T14:54:01.206-0500","logger":"logagent","msg":"no files match the configured include patterns","operator_id":"$.b92bee80-9ff6-4275-9922-da4a040ce873.hadoop_namenode_yarn_input","operator_type":"file_input","include":[""]}
{"level":"warn","ts":"2020-11-19T14:54:01.211-0500","logger":"logagent","msg":"no files match the configured include patterns","operator_id":"$.b92bee80-9ff6-4275-9922-da4a040ce873.hadoop_datanode_yarn_input","operator_type":"file_input","include":[""]}
{"level":"warn","ts":"2020-11-19T14:54:01.214-0500","logger":"logagent","msg":"no files match the configured include patterns","operator_id":"$.b92bee80-9ff6-4275-9922-da4a040ce873.hadoop_resourcemgr_yarn_input","operator_type":"file_input","include":[""]}
```


### Example configuration:
```
pipeline:
  - id: b92bee80-9ff6-4275-9922-da4a040ce873
    name: "Apache Hadoop "
    type: hadoop
    output:
      - 8053f8d8-06e1-4a47-b3e2-af418c3ceb39
    version: 0.0.1
    start_at: beginning
    enable_datanode_logs: true
    enable_namenode_logs: true
    datanode_yarn_log_path: ""
    namenode_yarn_log_path: ""
    enable_resourcemgr_logs: true
    datanode_general_log_path: /opt/hadoop/logs/hadoop-hadoop-datanode-oiq-int-hadoop.log
    namenode_general_log_path: /opt/hadoop/logs/hadoop-hadoop-namenode-oiq-int-hadoop.log
    resourcemgr_yarn_log_path: ""
    resourcemgr_general_log_path: /opt/hadoop/logs/hadoop-hadoop-resourcemanager-oiq-int-hadoop.log
```
