### PR TITLE
Fix parsing errors for slow query and general logs

### DIFF
--- a/plugins/mysql.yaml
+++ b/plugins/mysql.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 title: MySQL
 description: Log parser for MySQL
 parameters:
@@ -87,7 +87,7 @@ pipeline:
 
   - id: slow_query_regex_parser
     type: regex_parser
-    regex: '# Time: (?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z)\s# User@Host:\s+(?P<dbuser>\w+)\[(?P<dbname>\w+)\]\s+@\s+\[(?P<ip_address>[\d\.]+)\]\s+Id:\s+(?P<id>\d+)\s+#\s+Query_time:\s+(?P<query_time>[\d\.]+)\s+Lock_time:\s+(?P<lock_time>[\d\.]+)\s+Rows_sent:\s+(?P<rows_sent>\d+)\s+Rows_examined:\s(?P<rows_examined>\d+)\s+(?P<query>(?s).*[^\s])'
+    regex: '# Time: (?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z)\s# User@Host:\s+(?P<dbuser>\w+)\[(?P<dbname>\w+)\]\s+@\s+((?P<host>[^\s]+)\s)?\[(?P<ip_address>[\d\.]+|)\]\s+Id:\s+(?P<id>\d+)\s+#\s+Query_time:\s+(?P<query_time>[\d\.]+)\s+Lock_time:\s+(?P<lock_time>[\d\.]+)\s+Rows_sent:\s+(?P<rows_sent>\d+)\s+Rows_examined:\s(?P<rows_examined>\d+)\s+(?P<query>(?s).*[^\s])'
     timestamp:
       parse_from: timestamp
       layout: '%Y-%m-%dT%H:%M:%S.%sZ'
@@ -147,7 +147,7 @@ pipeline:
 
   - id: general_regex_parser
     type: regex_parser
-    regex: '(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z)\s+(?P<tid>\d+)\s+(?P<command>\w+)\s+(?P<message>(?s).+\S)'
+    regex: '(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z)\s+(?P<tid>\d+)\s+(?P<command>\w+)(\s+(?P<message>(?s).+\S))?'
     timestamp:
       parse_from: timestamp
       layout: '%Y-%m-%dT%H:%M:%S.%sZ'


### PR DESCRIPTION
- Added support for optional host field in `slow_query_regex_parser` to fix parsing issue.
- Made message field optional in `general_regex_parser` to fix parsing issue when no message is present.
