### PR TITLE
Filter iis startup log entries

### DIFF
--- a/plugins/microsoft_iis.yaml
+++ b/plugins/microsoft_iis.yaml
@@ -28,15 +28,18 @@ pipeline:
     include:
       - {{ $file_path }}
     multiline:
-      line_start_pattern: '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} '
+      line_start_pattern: '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} |#Software: |#Version: |#Date: |#Fields: '
     start_at: {{ $start_at }}
     labels:
       log_type: microsoft_iis
       plugin_id: {{ .id }}
-    output: microsoft_iis_parser
+
+  - type: filter
+    expr: '$record matches "#Software: |#Version: |#Date: |#Fields: "'
 
   - id: microsoft_iis_parser
     type: regex_parser
+    if: '$record matches "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} "'
     regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (?P<server_ip>[\d\w\.:]+) (?P<request_method>[A-Z]+) (?P<uri_stem>[^ ]+) (?P<uri_query>[^ ]+) (?P<server_port>\d+) (?P<username>[^ ]+) (?P<client_ip>[\d\w\.:]+) (?P<user_agent>[^ ]+) (?P<referer>[^ ]+) (?P<http_status>\d+) (?P<http_sub_status>\d+) (?P<win32_status>\d+) (?P<time_taken>\d+)'
     timestamp:
       parse_from: timestamp


### PR DESCRIPTION
Startup log entries causes parsing error failures.
- Updated line_start_pattern to handle startup log entries
- Added filter to drop startup log entries