### PR TITLE
Change plugin to use journald instead of file_input

### DIFF
--- a/plugins/memcached.yaml
+++ b/plugins/memcached.yaml
@@ -23,8 +23,9 @@ parameters:
 pipeline:
   - id: memcached_journald_input
     type: journald_input
-    include:
-      - {{ .memcached_journald_log_path }}
+    # {{ if .memcached_journald_log_path }}
+    directory: '{{ .memcached_journald_log_path }}'
+    # {{ end }}
     start_at: {{ $start_at }}
     labels:
       log_type: memcached

--- a/plugins/memcached.yaml
+++ b/plugins/memcached.yaml
@@ -3,11 +3,10 @@ version: 0.0.1
 title: Memcached
 description: Log parser for Memcached
 parameters:
-  - name: file_path
-    label: Memcached Logs Path
-    description: The absolute path to the Memcached logs
+  - name: memcached_journald_log_path
+    label: Memcached Journald Log Path
+    description: 'Memcached Journald Log path. It will read from /run/journal or /var/log/journal if this parameter is omitted'
     type: string
-    default: "/var/log/memcached.log*"
   - name: start_at
     label: Start At
     description: Start reading file from 'beginning' or 'end'
@@ -18,17 +17,32 @@ parameters:
     default: end
 
 # Set Defaults
-# {{$file_path := default "/var/log/memcached.log*" .file_path}}
 # {{$start_at := default "end" .start_at}}
 
 # Pipeline Template
 pipeline:
-  - id: memcached_input
-    type: file_input
+  - id: memcached_journald_input
+    type: journald_input
     include:
-      - {{ $file_path }}
+      - {{ .memcached_journald_log_path }}
     start_at: {{ $start_at }}
     labels:
       log_type: memcached
       plugin_id: {{ .id }}
-    output: {{.output}}
+
+  - id: memcached_filter
+    type: filter
+    expr: '$record._SYSTEMD_UNIT != "memcached.service"'
+
+  - type: severity_parser
+    parse_from: $record.PRIORITY
+    mapping:
+      emergency: 0
+      alert: 1
+      critical: 2
+      error: 3
+      warning: 4
+      notice: 5
+      info: 6
+      debug: 7
+    output: {{ .output }}


### PR DESCRIPTION
- use `journald_input` instead of `file_input`.
- filter out non memcached journald entries.
- parse severity from `PRIORITY` field.