### PR TITLE
Match date only at the start of line. Allow and filter empty message field.

### DIFF
--- a/plugins/oracledb.yaml
+++ b/plugins/oracledb.yaml
@@ -74,7 +74,7 @@ pipeline:
       - {{ $audit_log_path }}
     start_at: {{ $start_at }}
     multiline:
-      line_start_pattern: '[a-zA-z]+ [a-zA-Z]+ \d{2} \d{2}:\d{2}:\d{2} \d{4} [-+]\d{2}:\d{2}\n|Audit File '
+      line_start_pattern: '^[a-zA-z]+ [a-zA-Z]+ \d{2} \d{2}:\d{2}:\d{2} \d{4} [-+]\d{2}:\d{2}\n|^Audit File '
     labels:
       log_type: 'oracledb.audit'
       plugin_id: {{ .id }}
@@ -121,7 +121,7 @@ pipeline:
       - {{ $alert_log_path }}
     start_at: {{ $start_at }}
     multiline:
-      line_start_pattern: '\w+ \w+ \d{2} \d{2}:\d{2}:\d{2} \d{4}|\d{4}-\d{2}-\d{2}T\d{1,}:\d{2}:\d{2}.\d+[+-]\d+:\d+|<msg time=\D\d{4}-\d{2}-\d{2}T\d{1,}:\d{2}:\d{2}.\d+[+-]\d+:\d+'
+      line_start_pattern: '^\w+ \w+ \d{2} \d{2}:\d{2}:\d{2} \d{4}|\d{4}-\d{2}-\d{2}T\d{1,}:\d{2}:\d{2}.\d+[+-]\d+:\d+|^<msg time=\D\d{4}-\d{2}-\d{2}T\d{1,}:\d{2}:\d{2}.\d+[+-]\d+:\d+'
     labels:
       log_type: 'oracledb.alert'
       plugin_id: {{ .id }}
@@ -131,12 +131,13 @@ pipeline:
     type: router
     routes:
       - output: xml_alert_regex_parser
-        expr: $ matches '<msg time=\\D\\d{4}-\\d{2}-\\d{2}T\\d{1,}:\\d{2}:\\d{2}.\\d+[+-]\\d+:\\d+'
+        expr: $ matches '^<msg time=\\D\\d{4}-\\d{2}-\\d{2}T\\d{1,}:\\d{2}:\\d{2}.\\d+[+-]\\d+:\\d+'
       - output: alert121_regex_parser
-        expr: $ matches '\\w+ \\w+ \\d{2} \\d{2}:\\d{2}:\\d{2} \\d{4}'
+        expr: $ matches '^\\w+ \\w+ \\d{2} \\d{2}:\\d{2}:\\d{2} \\d{4}'
       - output: alert122_regex_parser
-        expr: $ matches '\\d{4}-\\d{2}-\\d{2}T\\d{1,}:\\d{2}:\\d{2}.\\d+[+-]\\d+:\\d+'
-
+        expr: $ matches '^\\d{4}-\\d{2}-\\d{2}T\\d{1,}:\\d{2}:\\d{2}.\\d+[+-]\\d+:\\d+'
+  
+  # Alert log looks to be xml attempt to parse with regex
   - id: xml_alert_regex_parser
     type: regex_parser
     regex: '^<msg\s+time=\D(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}[+-]\d{2}:\d{2})\D(\s+)?(org_id=\D(?P<org_id>[\w\d]+)\D)?(\s+)?(comp_id=\D(?P<comp_id>[\w\d]+)\D)?(\s+)?(msg_id=\D(?P<msg_id>[\w\d:]+)\D)?(\s+)?(type=\D(?P<type>\w+)\D)?(\s+)?(group=\D(?P<group>[\w ]+)\D)?(\s+)?(level=\D(?P<level>\d+)\D)?(\s+)?(host_id=\D(?P<host_id>[\.\w\d-_]+)\D)?(\s+)?(host_addr=\D(?P<host_addr>[\d\.]+)\D)?(\s+)?(module=\D(?P<module>[\w-\s@()]+)\D)?(\s+)?(pid=\D(?P<pid>\d+)\D)?(\s+)?(\s+)?(version=\D(?P<version>\d+)\D)?(\s+)?>\s+<txt>(?P<txt>[\d\D\s]+)</txt>(\s+)?</msg>'
@@ -148,20 +149,26 @@ pipeline:
   # Alert log parser for 12.1 timestamp
   - id: alert121_regex_parser
     type: regex_parser
-    regex: '(?P<timestamp>\w+ \w+ \d{2} \d{2}:\d{2}:\d{2} \d{4})\n(?P<message>[\d\w[:ascii:]]+)'
+    regex: '(?P<timestamp>\w+ \w+ \d{2} \d{2}:\d{2}:\d{2} \d{4})\n((?P<message>[\d\w[:ascii:]]*))?'
     timestamp:
       parse_from: timestamp
       layout: '%c'
-    output: {{ .output }}
+    output: regex_empty_message_filter
 
   # Alert log parser for 12.2 timestamp
   - id: alert122_regex_parser
     type: regex_parser
-    regex: '(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{1,}:\d{2}:\d{2}.\d+[+-]\d+:\d+)\n(?P<message>[\d\w[:ascii:]]+)'
+    regex: '(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{1,}:\d{2}:\d{2}.\d+[+-]\d+:\d+)\n((?P<message>[\d\w[:ascii:]]*))?'
     timestamp:
       parse_from: timestamp
       layout: '%Y-%m-%dT%T.%s%j'
+    output: regex_empty_message_filter
+
+  - id: regex_empty_message_filter
+    type: filter
+    expr: '$record.message == ""'
     output: {{ .output }}
+
   # {{ end }}
 
   # {{ if $enable_listener_log }}


### PR DESCRIPTION
- Updated alert `line_start_pattern` to match date only at start of line.
- Updated alert regex to make message field optional. This is to resolve parsing error but creates empty message field.
- Added filter to remove log entries with empty message fields.