### PR TITLE
Fix parsing errors for slow query

### DIFF
--- a/plugins/mysql.yaml
+++ b/plugins/mysql.yaml
@@ -87,7 +87,7 @@ pipeline:
 
   - id: slow_query_regex_parser
     type: regex_parser
-    regex: '# Time: (?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z)\s# User@Host:\s+(?P<dbuser>\w+)\[(?P<dbname>\w+)\]\s+@\s+((?P<host>[^\s]+)\s)?\[(?P<ip_address>[\d\.]+|)\]\s+Id:\s+(?P<id>\d+)\s+#\s+Query_time:\s+(?P<query_time>[\d\.]+)\s+Lock_time:\s+(?P<lock_time>[\d\.]+)\s+Rows_sent:\s+(?P<rows_sent>\d+)\s+Rows_examined:\s(?P<rows_examined>\d+)\s+(?P<query>(?s).*[^\s])'
+    regex: '# Time: (?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z)\s# User@Host:\s+(?P<dbuser>[^\[]*)\[(?P<dbname>[^\]]*)\]\s+@\s+((?P<host>[^\s]+)\s)?\[(?P<ip_address>[\w\d\.:]*)\]\s+Id:\s+(?P<id>\d+)\s+#\s+Query_time:\s+(?P<query_time>[\d\.]+)\s+Lock_time:\s+(?P<lock_time>[\d\.]+)\s+Rows_sent:\s+(?P<rows_sent>\d+)\s+Rows_examined:\s(?P<rows_examined>\d+)\s+(?P<query>(?s).*[^\s])'
     timestamp:
       parse_from: timestamp
       layout: '%Y-%m-%dT%H:%M:%S.%sZ'


### PR DESCRIPTION
Update Regex for `dbuser` and `dbname` fields to allow non letter characters. Also allow IPv6 addresses in ip_address field.