### PR TITLE
Fix Windows DHCP parsing errors and filter startup log entries

### DIFF
--- a/plugins/windows_dhcp.yaml
+++ b/plugins/windows_dhcp.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.5
+version: 0.0.6
 title: Windows DHCP
 description: Log parser for Windows DHCP
 supported_platforms: 
@@ -33,12 +33,32 @@ pipeline:
     labels:
       log_type: windows_dhcp
       plugin_id: {{ .id }}
-    output: windows_dhcp_parser
+    output: filter_router
+
+  - id: filter_router
+    type: router
+    routes:
+      - output: log_start_filter
+        expr: '$record matches "^\\t\\tMicrosoft DHCP"'
+      - output: log_start_filter
+        expr: '$record matches "^Event ID  Meaning"'
+      - output: log_start_filter
+        expr: '$record matches "^\\d*\tThe log was started"'
+      - output: log_start_filter
+        expr: '$record matches "^QResult: "'
+      - output: log_start_filter
+        expr: '$record matches "^ID,Date,Time,Description,"'
+      - output: windows_dhcp_parser
+        expr: '$record matches "^\\d+,\\d{2}\\/\\d{2}\\/\\d{2},\\d{2}:\\d{2}:\\d{2}"'
+
+  # This section filters out log description entries gathered from start of log file
+  - id: log_start_filter
+    type: filter
+    expr: true
 
   - id: windows_dhcp_parser
     type: regex_parser
-    if: '$record matches "^\\d+,\\d{2}\\/\\d{2}\\/\\d{2},\\d{2}:\\d{2}:\\d{2}"'
-    regex: '^(?P<id>\d+),(?P<timestamp>\d{2}\/\d{2}\/\d{2},\d{2}:\d{2}:\d{2}),(?P<description>[^,]+),(?P<ip_address>[^,]*),(?P<hostname>[^,]*),(?P<mac_address>[^,]*),(?P<username>[^,]*),(?P<transaction_id>[^,]*),(?P<q_result>[^,]*),(?P<probation_time>[^,]*),(?P<correlation_id>[^,]*),(?P<dhc_id>[^,]*),(?P<vendor_class_hex>[^,]*),(?P<vendor_class_ascii>[^,]*),(?P<user_Class_hex>[^,]*),(?P<user_class_ascii>[^,]*),(?P<relay_agent_info>[^,]*),(?P<dns_reg_error>[^,]*)'
+    regex: '^(?P<id>\d+),(?P<timestamp>\d{2}\/\d{2}\/\d{2},\d{2}:\d{2}:\d{2}),(?P<description>[^,]+),(?P<ip_address>[^,]*),(?P<hostname>[^,]*),(?P<mac_address>[^,]*),(?P<username>[^,]*),(?P<transaction_id>[^,]*),(?P<q_result>[^,]*),(?P<probation_time>[^,]*),(?P<correlation_id>[^,]*),(?P<dhc_id>[^,]*),(?P<vendor_class_hex>[^,]*)(,(?P<vendor_class_ascii>[^,]*),(?P<user_Class_hex>[^,]*),(?P<user_class_ascii>[^,]*),(?P<relay_agent_info>[^,]*),(?P<dns_reg_error>[^,]*))?'
     timestamp:
       parse_from: timestamp
       layout: '%m/%d/%y,%H:%M:%S'


### PR DESCRIPTION
Windows DHCP 2019 test environment we use does not include fields past `vendor_class_hex` field. 
- Set fields `vendor_class_ascii`, `user_Class_hex`, `user_class_ascii`, `relay_agent_info`, and `dns_reg_error` as optional to fix parsing errors.
- Filter start up log messages at beginning of file.
