### PR TITLE
Fix parsing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.26] - Unreleased
 ### Changed
+- Update `couchdb` plugin ([PR126](https://github.com/observIQ/stanza-plugins/pull/126))
+  - Allow `-` character in regex parser. Replaced `\w+` with `[\w-]+`
+  - Made `hostname` and `port` optional as they are not always present in the logs.
+- Update `mysql` plugin ([PR123](https://github.com/observIQ/stanza-plugins/pull/123))
+  - Bump version
 - Update `windows_dhcp` plugin ([PR122](https://github.com/observIQ/stanza-plugins/pull/122))
   - Set fields `vendor_class_ascii`, `user_Class_hex`, `user_class_ascii`, `relay_agent_info`, and `dns_reg_error` as optional to fix parsing errors.
   - Filter start up log messages at beginning of file.
-- Update `mysql` pluging ([PR123](https://github.com/observIQ/stanza-plugins/pull/123))
-  - Bump version
 
 ## [0.0.25] - 2020-12-07
 ### Changed

--- a/plugins/couchdb.yaml
+++ b/plugins/couchdb.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.2
+version: 0.0.3
 title: CouchDB
 description: Log parser for CouchDB
 parameters:
@@ -33,11 +33,10 @@ pipeline:
     labels:
       log_type: couchdb
       plugin_id: {{ .id }}
-    output: couchdb_parser
 
   - id: couchdb_parser
     type: regex_parser
-    regex: '^\[(?P<couchdb_severity>\w*)\] (?P<timestamp>[\d\-\.:TZ]+) (?P<user>\w+)@(?P<upstream_host>[^\s]+) <[^>]+> \w+ (?P<hostname>[\w-]+):(?P<port>\d+) (?P<message>.*)'
+    regex: '^\[(?P<couchdb_severity>\w*)\] (?P<timestamp>[\d\-\.:TZ]+) (?P<user>\w+)@(?P<upstream_host>[^\s]+) <[^>]+> [\w-]+ ((?P<hostname>[\w-]+):(?P<port>\d+) )?(?P<message>.*)'
     timestamp:
       parse_from: timestamp
       layout: '%Y-%m-%dT%H:%M:%S.%sZ'
@@ -47,5 +46,6 @@ pipeline:
         info: notice
         warning: warn
         error: err
+        critical: crit
         emergency: emerg
     output: {{.output}}


### PR DESCRIPTION
Fix parsing errors. 
- Allow `-` character in regex parser. Replaced `\w+` with `[\w-]+`
- Made `hostname` and `port` optional as they are not always present in the logs.