### PR TITLE
Nginx k8s log type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.26] - Unreleased
 ### Changed
+- Update `nginx` plugin ([PR128](https://github.com/observIQ/stanza-plugins/pull/128))
+  - Add labels `log_type` and `plugin_id` when source is Kubernetes.
 - Update `hbase` plugin ([PR127](https://github.com/observIQ/stanza-plugins/pull/127))
   - Remove routers in favor of `if:` parameter in regexs
   - Add `thread` and `hbase_source` fields to stardard_parsers for each log type.
 - Update `couchdb` plugin ([PR126](https://github.com/observIQ/stanza-plugins/pull/126))
   - Allow `-` character in regex parser. Replaced `\w+` with `[\w-]+`
   - Made `hostname` and `port` optional as they are not always present in the logs.
+- Update `nginx` plugin ([PR](https://github.com/observIQ/stanza-plugins/pull/124))
+  - Specified supported platforms
 - Update `mysql` plugin ([PR123](https://github.com/observIQ/stanza-plugins/pull/123))
   - Bump version
 - Update `windows_dhcp` plugin ([PR122](https://github.com/observIQ/stanza-plugins/pull/122))
   - Set fields `vendor_class_ascii`, `user_Class_hex`, `user_class_ascii`, `relay_agent_info`, and `dns_reg_error` as optional to fix parsing errors.
   - Filter start up log messages at beginning of file.
-- Update `nginx` plugin ([PR](https://github.com/observIQ/stanza-plugins/pull/124))
-  - Specified supported platforms
 
 ## [0.0.25] - 2020-12-07
 ### Changed

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -31,6 +31,13 @@ parameters:
     relevant_if:
       source:
         equals: kubernetes
+  - name: cluster_name
+    label: Cluster Name
+    description: 'Cluster Name to be added to a resource label'
+    type: string
+    relevant_if:
+      source:
+        equals: kubernetes
   - name: enable_access_log
     label: Access Logs
     description: Enable to collect Nginx access logs
@@ -80,6 +87,7 @@ parameters:
 
 # Set Defaults
 # {{$source := default "file" .source}}
+# {{ $cluster_name := default "" .cluster_name }}
 # {{$enable_access_log := default true .enable_access_log}}
 # {{$access_log_path := default "/var/log/nginx/access.log*" .access_log_path}}
 # {{$enable_error_log := default true .enable_error_log}}
@@ -95,6 +103,7 @@ pipeline:
     type: kubernetes_container
     pod_name: '{{ $pod_name }}'
     container_name: '{{ $container_name }}'
+    cluster_name: '{{ $cluster_name }}'
     start_at: '{{ $start_at }}'
 
   - id: k8s_input_router

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -31,13 +31,6 @@ parameters:
     relevant_if:
       source:
         equals: kubernetes
-  - name: cluster_name
-    label: Cluster Name
-    description: 'Cluster Name to be added to a resource label'
-    type: string
-    relevant_if:
-      source:
-        equals: kubernetes
   - name: enable_access_log
     label: Access Logs
     description: Enable to collect Nginx access logs
@@ -87,7 +80,6 @@ parameters:
 
 # Set Defaults
 # {{$source := default "file" .source}}
-# {{ $cluster_name := default "" .cluster_name }}
 # {{$enable_access_log := default true .enable_access_log}}
 # {{$access_log_path := default "/var/log/nginx/access.log*" .access_log_path}}
 # {{$enable_error_log := default true .enable_error_log}}
@@ -103,7 +95,6 @@ pipeline:
     type: kubernetes_container
     pod_name: '{{ $pod_name }}'
     container_name: '{{ $container_name }}'
-    cluster_name: '{{ $cluster_name }}'
     start_at: '{{ $start_at }}'
 
   - id: k8s_input_router

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -98,10 +98,16 @@ pipeline:
       # {{ if $enable_access_log }}
       - expr: "$labels.stream == 'stdout'"
         output: access_regex_parser
+        labels:
+          log_type: 'kubernetes.nginx.access'
+          plugin_id: '{{ .id }}'
       # {{ end }}
       # {{ if $enable_error_log }}
       - expr: "$labels.stream == 'stderr'"
         output: error_regex_parser
+        labels:
+          log_type: 'kubernetes.nginx.error'
+          plugin_id: '{{ .id }}'
       # {{ end }}
   # {{ end }}
 


### PR DESCRIPTION
When using NGINX source with Kubernetes the NGINX log_type was not added. This update will add types kubernetes.nginx.access and kubernetes.nginx.error to respective log types.
- Add labels `log_type` and `plugin_id` when source is Kubernetes.