### PR TITLE
Update HBase to fix  field regex parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.27] - Unreleased
+### Changed
+- Update `hbase` plugin ([PR129](https://github.com/observIQ/stanza-plugins/pull/129))
+  - Change `thread` field regex to capture all characters
+
 ## [0.0.26] - 2020-12-10
 ### Changed
 - Update `nginx` plugin ([PR128](https://github.com/observIQ/stanza-plugins/pull/128))

--- a/plugins/hbase.yaml
+++ b/plugins/hbase.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.3
+version: 0.0.4
 title: Apache HBase
 description: Log parser for Apache HBase
 parameters:
@@ -77,7 +77,7 @@ pipeline:
   - id: master_standard_regex_parser
     type: regex_parser
     if:  '$record matches "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3}\\s+"'
-    regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\s+(?P<hbase_severity>[A-Z]*)\s*?\[(?P<thread>[\w]*)\]\s(?P<hbase_source>[^:]*):\s(?P<message>(?s).*)\n'
+    regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\s+(?P<hbase_severity>[A-Z]*)\s*?\[(?P<thread>[^\]]*)\]\s(?P<hbase_source>[^:]*):\s(?P<message>(?s).*)\n'
     timestamp:
       parse_from: timestamp
       layout: '%Y-%m-%d %H:%M:%S'
@@ -114,7 +114,7 @@ pipeline:
   - id: region_standard_regex_parser
     type: regex_parser
     if:  '$record matches "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3}\\s+"'
-    regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\s+(?P<hbase_severity>[A-Z]*)\s*?\[(?P<thread>[\w]*)\]\s(?P<hbase_source>[^:]*):\s(?P<message>(?s).*)\n'
+    regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\s+(?P<hbase_severity>[A-Z]*)\s*?\[(?P<thread>[^\]]*)\]\s(?P<hbase_source>[^:]*):\s(?P<message>(?s).*)\n'
     timestamp:
       parse_from: timestamp
       layout: '%Y-%m-%d %H:%M:%S'
@@ -151,7 +151,7 @@ pipeline:
   - id: zookeeper_standard_regex_parser
     type: regex_parser
     if:  '$record matches "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3}\\s+"'
-    regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\s+(?P<hbase_severity>[A-Z]*)\s*?\[(?P<thread>[\w]*)\]\s(?P<hbase_source>[^:]*):\s(?P<message>(?s).*)\n'
+    regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\s+(?P<hbase_severity>[A-Z]*)\s*?\[(?P<thread>[^\]]*)\]\s(?P<hbase_source>[^:]*):\s(?P<message>(?s).*)\n'
     timestamp:
       parse_from: timestamp
       layout: '%Y-%m-%d %H:%M:%S'


### PR DESCRIPTION
Fix parsing error with thread field when it contains non word characters e.g. `main-SendThread(127.0.0.1:2181)`.
- Change `thread` field regex to capture all characters