### PR TITLE
Cluster name restructurer

### DIFF
--- a/plugins/kubernetes_cluster.yaml
+++ b/plugins/kubernetes_cluster.yaml
@@ -82,15 +82,6 @@ pipeline:
   # Add kubernetes metadata
   - id: add_kubernetes_metadata
     type: k8s_metadata_decorator
-    output: cluster_name_restructurer
-
-  # Add kubernetes cluster name after adding metadata so it doesn't get overwritten
-  - id: cluster_name_restructurer
-    type: restructure
-    ops:
-      - add:
-          field: "$resource['k8s.cluster.name']"
-          value: "{{ $cluster_name }}"
     output: add_labels_router
 
   # Add label log_type

--- a/plugins/kubernetes_cluster.yaml
+++ b/plugins/kubernetes_cluster.yaml
@@ -93,7 +93,7 @@ pipeline:
           value: "{{ $cluster_name }}"
     output: add_labels_router
 
-# Add label log_type
+  # Add label log_type
   - id: add_labels_router
     type: router
     routes:

--- a/plugins/kubernetes_cluster.yaml
+++ b/plugins/kubernetes_cluster.yaml
@@ -1,7 +1,7 @@
 version: 0.0.8
 title: Kubernetes Cluster
 description: Log parser for Kubernetes
-supported_platforms: 
+supported_platforms:
   - kubernetes
 parameters:
   - name: container_log_path
@@ -84,7 +84,16 @@ pipeline:
     type: k8s_metadata_decorator
     output: cluster_name_restructurer
 
-  # Add label log_type
+  # Add kubernetes cluster name after adding metadata so it doesn't get overwritten
+  - id: cluster_name_restructurer
+    type: restructure
+    ops:
+      - add:
+          field: "$resource['k8s.cluster.name']"
+          value: "{{ $cluster_name }}"
+    output: add_labels_router
+
+# Add label log_type
   - id: add_labels_router
     type: router
     routes:


### PR DESCRIPTION
I think when this was split out, it got removed and causes the following error:

```
{"level":"error","ts":"2020-12-11T21:13:55.055Z","logger":"logagent","msg":"Failed to create new log agent","error":{"description":"operator '$.d9e3a4fe-ec2b-4a77-b772-52dfc3cf10c6.cluster_name_restructurer' does not exist","details":{"operator_id":"$.d9e3a4fe-ec2b-4a77-b772-52dfc3cf10c6.add_kubernetes_metadata"}}}
```