### PR TITLE
Update field names to be most descriptive. Remove agent parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `kubernetes_container` plugin ([PR136](https://github.com/observIQ/stanza-plugins/pull/136))
   - Specified output for the plugin so it can be directed.
+- Update `apache_http` plugin ([PR135](https://github.com/observIQ/stanza-plugins/pull/135))
+  - Updated regex group names to be more descriptive and more inline with docs and nginx.
+  - Removed agent parsing.
 
 ## [0.0.28] - 2020-12-15
 ### Changed

--- a/plugins/apache_http.yaml
+++ b/plugins/apache_http.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 title: Apache HTTP Server
 description: Log parser for Apache HTTP Server
 parameters:
@@ -57,36 +57,19 @@ pipeline:
 
   - id: access_regex_parser
     type: regex_parser
-    regex: '^(?P<remote>[^ ]*) (?P<host>[^ ]*) (?P<user>[^ ]*) \[(?P<time>[^\]]*)\] "(?P<method>\S+)(?: +(?P<path>[^\"]*?)(?: +\S*)?)?" (?P<code>[^ ]*) (?P<size>[^ ]*)(?: "(?P<referer>[^\"]*)" "(?P<agent>[^\"]*)"(?:\s+(?P<http_x_forwarded_for>[^ ]+))?)?'
+    regex: '^(?P<remote_addr>[^ ]*) (?P<remote_host>[^ ]*) (?P<remote_user>[^ ]*) \[(?P<time>[^\]]*)\] "(?P<method>\S+)(?: +(?P<path>[^\"]*?)(?: +\S*)?)?" (?P<status>[^ ]*) (?P<body_bytes_sent>[^ ]*)(?: "(?P<http_referer>[^\"]*)" "(?P<http_user_agent>[^\"]*)"(?:\s+(?P<http_x_forwarded_for>[^ ]+))?)?'
     timestamp:
       parse_from: time
       layout: '%d/%b/%Y:%H:%M:%S %z'
-    output: access_agent_router
     severity:
-      parse_from: code
+      parse_from: status
       preset: none
-      preserve_to: code
+      preserve_to: status
       mapping:
         info: 2xx
         notice: 3xx
         warning: 4xx
         error: 5xx
-
-  # Router to determine if agent field can be parsed.
-  - id: access_agent_router
-    type: router
-    routes:
-      - expr: '$record.agent != nil and $record.agent matches "^(?P<client>[^/]*)/(?P<client_version>[^ ]*) (\\((?P<system>[^;]*);([^\\)]*)\\))?(.*)?"'
-        output: access_agent_parser
-      - expr: true
-        output: {{ .output }}
-
-  # Parse agent field
-  - id: access_agent_parser
-    type: regex_parser
-    regex: '^(?P<client>[^/]*)/(?P<client_version>[^ ]*) (\((?P<system>[^;]*);([^\)]*)\))?(.*)?'
-    parse_from: agent
-    preserve_to: agent
     output: {{ .output }}
   #{{ end }}
 


### PR DESCRIPTION
Updated regex group names to be more descriptive and more inline with docs and nginx. Removed agent parsing as that is handled by Observiq.

**Field Name Changes**
```
remote -> remote_addr
host -> remote_host
user -> remote_user
code -> status
size -> body_bytes_sent
agent -> http_user_agent
```