### PR TITLE
Specify output for the kubernetes_container plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.29] - Unreleased
+### Changed
+- Update `kubernetes_container` plugin ([PR136](https://github.com/observIQ/stanza-plugins/pull/136))
+  - Specified output for the plugin so it can be directed.
+
 ## [0.0.28] - 2020-12-15
 ### Changed
 - Update `nginx` plugin ([PR133](https://github.com/observIQ/stanza-plugins/pull/133))

--- a/plugins/kubernetes_container.yaml
+++ b/plugins/kubernetes_container.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 title: Kubernetes Container
 id: kubernetes
 description: Log parser for Kubernetes
@@ -101,3 +101,4 @@ pipeline:
       - move:
           from: log
           to: "$record"
+    output: {{ .output }}


### PR DESCRIPTION
Was noticing this error when trying to use this plugin specifying an output, I believe that it was trying to output into the next part of my pipeline and not to the specified output. 

``` 
{"level":"error","ts":"2020-12-17T20:08:20.529Z","logger":"logagent","msg":"Failed to create new log agent","error":{"description":"operator '$.bf953201-1229-473e-a6b6-d523b8a1e04b' does not exist","details":{"operator_id":"$.7387b6f1-fb85-4815-bcf9-df579500fcca.restructure
```

For this pipeline:
```
pipeline:
- access_log_path: /var/log/nginx/access.log*
  container_name: '*'
  enable_access_log: true
  enable_error_log: true
  error_log_path: /var/log/nginx/error.log*
  format_ingress: false
  id: 605933a2-faa8-4db4-a534-4be37b7d802e
  name: local-nginx
  output:
  - 20db1417-a248-4c1e-b19e-346c6fd73e41
  pod_name: nginx
  source: kubernetes
  start_at: end
  type: nginx
  version: 0.0.6
- id: 20db1417-a248-4c1e-b19e-346c6fd73e41
  type: cabin_output
  endpoint: http://192.168.64.1:4017
- cluster_name: minikube
  container_name: '*'
  id: 7387b6f1-fb85-4815-bcf9-df579500fcca
  output:
  - 20db1417-a248-4c1e-b19e-346c6fd73e41
  pod_name: '*'
  start_at: end
  type: kubernetes_container
  version: 0.0.8
- cluster_name: minikube
  container_log_path: /var/log/containers/
  id: bf953201-1229-473e-a6b6-d523b8a1e04b
  kubelet_journald_log_path: ""
  output:
  - 20db1417-a248-4c1e-b19e-346c6fd73e41
  start_at: end
  type: kubernetes_cluster
  version: 0.0.9
```