### PR TITLE
Bpagent log type

### DIFF
--- a/plugins/bindplane_agent.yaml
+++ b/plugins/bindplane_agent.yaml
@@ -1,0 +1,45 @@
+version: 0.0.1
+title: BindPlane Universal Agent
+description: Agent logs for the BindPlane Universal Agent
+parameters:
+  - name: start_at
+    label: Start At
+    description:  Start reading file from 'beginning' or 'end'
+    type: enum
+    valid_values:
+      - beginning
+      - end
+    default: end
+pipeline:
+
+  - id: log_reader
+    type: file_input
+    include:
+      - log/manager.log
+      - log/launcher.log
+    start_at: {{ or .start_at "end" }}
+    labels:
+      log_type: bindplane.agent
+      plugin_id: {{ .id }}
+
+  - id: log_json_parser
+    type: json_parser
+    severity:
+      parse_from: level
+    timestamp:
+      parse_from: ts
+      preserve: false
+      layout_type: gotime
+      layout: '2006-01-02T15:04:05.000-0700'
+
+  - id: log_restructure
+    type: restructure
+    ops:
+      - move:
+          from: logger
+          to: $labels.logger
+    output: {{ .output }}
+
+  - id: stanza_log
+    type: stanza_input
+    output: {{ .output }}

--- a/plugins/bpagent.yaml
+++ b/plugins/bpagent.yaml
@@ -1,4 +1,4 @@
-version: 0.0.2
+version: 0.0.3
 title: BindPlane / observIQ Universal Agent
 description: Agent logs for the BindPlane / observIQ Universal Agent
 parameters:

--- a/plugins/bpagent.yaml
+++ b/plugins/bpagent.yaml
@@ -19,6 +19,7 @@ pipeline:
       - log/launcher.log
     start_at: {{ or .start_at "end" }}
     labels:
+      log_type: observiq.agent
       plugin_id: {{ .id }}
 
   - id: log_json_parser

--- a/plugins/observiq_agent.yaml
+++ b/plugins/observiq_agent.yaml
@@ -1,6 +1,6 @@
-version: 0.0.3
-title: BindPlane / observIQ Universal Agent
-description: Agent logs for the BindPlane / observIQ Universal Agent
+version: 0.0.1
+title: observIQ Agent
+description: Agent logs for the observIQ Agent
 parameters:
   - name: start_at
     label: Start At


### PR DESCRIPTION
Splits plugin into two plugins. One plugin for BindPlane and one plugin for observIQ. 
- Rename bpagent.yaml to observiq_agent.yaml
- Create bindplane_agent.yaml
- Add `log_type` parameter to labels