### PR TITLE
Split process_start_time field to not include process id

### DIFF
--- a/plugins/postgresql.yaml
+++ b/plugins/postgresql.yaml
@@ -49,7 +49,7 @@ pipeline:
   - id: general_regex_parser
     type: regex_parser
     parse_from: log_entry
-    regex: '^t=(?P<time>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\s+[^\s]+)\s+p=(?P<process_id>\d*)\s+s=(?P<process_start_time>[^\s]*)\s+l=(?P<process_log_line>[^\s]*)\s+u=(?P<user_name>[^\s]*)\s+db=(?P<database>[^\s]*)\s+r=(?P<client_address>[^\s]*)\s*((LOG:\s*duration:\s*(?P<duration>[\w\.]*)\s*ms\s*(statement:\s*)?)|(LOG:\s*)|(DETAIL:\s*(parameters:\s*(?P<parameters>[\w\W]+))?)|(STATEMENT:\s*(?P<statement>[\w\W]+))|ERROR:\s*(?P<error>.[\w\W]+)|)(?P<message>[\w\W]+)?'
+    regex: '^t=(?P<time>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\s+[^\s]+)\s+p=(?P<process_id>\d*)\s+s=(?P<process_start_time>[^\.]*)\.[^\s]+\s+l=(?P<process_log_line>[^\s]*)\s+u=(?P<user_name>[^\s]*)\s+db=(?P<database>[^\s]*)\s+r=(?P<client_address>[^\s]*)\s*((LOG:\s*duration:\s*(?P<duration>[\w\.]*)\s*ms\s*(statement:\s*)?)|(LOG:\s*)|(DETAIL:\s*(parameters:\s*(?P<parameters>[\w\W]+))?)|(STATEMENT:\s*(?P<statement>[\w\W]+))|ERROR:\s*(?P<error>.[\w\W]+)|)(?P<message>[\w\W]+)?'
     timestamp:
       parse_from: time
       layout: '%F %T %Z'


### PR DESCRIPTION
This removes the process id portion of the `process_start_time` field. We already capture process id in another field and we will be able to parse the time once stanza update is released with unix hex time parser.
- Update `process_start_time`