### PR TITLE
OpenShift: Use _COMM for identifying container logs instead of _SYSTEMD_UNIT

### DIFF
--- a/plugins/openshift.yaml
+++ b/plugins/openshift.yaml
@@ -56,13 +56,13 @@ pipeline:
   - type: router
     routes:
       # Ignore logs written by Stanza to avoid circular parsing
-      - expr: '$record._SYSTEMD_UNIT == "docker.service" and $record.CONTAINER_NAME != nil and $record.CONTAINER_NAME matches "stanza"'
+      - expr: '$record._COMM == "dockerd-current" and $record.CONTAINER_NAME != nil and $record.CONTAINER_NAME matches "stanza"'
         output: drop_output
       # Send all container logs to the container name parser
-      - expr: '$record._SYSTEMD_UNIT == "docker.service" and $record.CONTAINER_NAME != nil'
+      - expr: '$record._COMM == "dockerd-current" and $record.CONTAINER_NAME != nil'
         output: '{{ if $enable_container_logs -}} regex_parser {{- else -}} drop_output {{- end }}'
       # Send all docker logs to the be labeled
-      - expr: '$record._SYSTEMD_UNIT == "docker.service"'
+      - expr: '$record._COMM == "dockerd-current"'
         output: {{ if $enable_docker_logs -}} {{ .output }} {{- else -}} drop_output {{- end }}
         labels:
           log_type: 'docker'


### PR DESCRIPTION
I have two OpenShift clusters. One is working well, the other acts as if there are no container logs. Each cluster has the same version of OpenShift, Docker, SystemD / JournalD.

The root cause seems to be related to these issues:

https://github.com/systemd/systemd/issues/6565
https://github.com/systemd/systemd/issues/2913

Because `_SYSTEMD_UNIT` is sometimes not available, and `_COMM` is available during both situations, I have opted to use `_COMM` for identifying docker container logs.

I can show this off in both of my environments, before and after making this change.