### PR TITLE
Update JBoss to remove preserve_to severity field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.32] - Unreleased
 ### Changed
-
+- Update `jboss` plugin ([PR151](https://github.com/observIQ/stanza-plugins/pull/151))
+  - Remove `jboss_severity` field
 ## [0.0.31] - 2020-12-30
 ### Removed
 - Remove `bpagent` plugin ([PR144](https://github.com/observIQ/stanza-plugins/pull/144))

--- a/plugins/jboss.yaml
+++ b/plugins/jboss.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.2
+version: 0.0.3
 title: JBoss
 description: 'Log parser for JBoss. This plugin expects the following starting format: %d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t)'
 parameters:
@@ -43,7 +43,6 @@ pipeline:
       layout: '%Y-%m-%d %H:%M:%S'
     severity:
       parse_from: jboss_severity
-      preserve_to: jboss_severity
       mapping:
         emergency: fatal
         warning: warn


### PR DESCRIPTION
Update jboss_severity parser to remove the preserve_to field.
- Remove `jboss_severity` field