### PR TITLE
Sap hana exclude nameserver history trace file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.33] - Unreleased
 ### Changed
 - Update `sap_hana` plugin ([PR151](https://github.com/observIQ/stanza-plugins/pull/151))
-  - Remove `file_path` parameter
-  - Add `logs_directory` parameter
-  - Add `file_name` parameter
-  - Remove `preserve_to` parameter
+  - Remove `file_path` and `preserve_to` parameter
+  - Add `file_name` and `logs_directory` parameter
+  - Exclude `nameserver_history*.trc`, `nameserver*loads*.trc`, `nameserver*unloads*.trc`, and `nameserver*executed_statements*.trc` files
 ## [0.0.32] - 2021-01-04
 ### Changed
 - Fixed exclude for `kubernetes_container` plugin ([PR152](https://github.com/observIQ/stanza-plugins/pull/152))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.32] - Unreleased
 ### Changed
-- Update `jboss` plugin ([PR151](https://github.com/observIQ/stanza-plugins/pull/151))
-  - Remove `jboss_severity` field
+- Update `sap_hana` plugin ([PR153](https://github.com/observIQ/stanza-plugins/pull/153))
+  - Add exclude for `nameserver_history.trc` file.
 - Fixed exclude for `kubernetes_container` plugin ([PR152](https://github.com/observIQ/stanza-plugins/pull/152))
-
+- Update `jboss` plugin ([PR151](https://github.com/observIQ/stanza-plugins/pull/151))
+  - Remove `jboss_severity` fieldß
 ## [0.0.31] - 2020-12-30
 ### Removed
 - Remove `bpagent` plugin ([PR144](https://github.com/observIQ/stanza-plugins/pull/144))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.33] - Unreleased
+### Changed
+- Update `sap_hana` plugin ([PR151](https://github.com/observIQ/stanza-plugins/pull/151))
+  - Remove `file_path` parameter
+  - Add `logs_directory` parameter
+  - Add `file_name` parameter
+  - Remove `preserve_to` parameter
 ## [0.0.32] - 2021-01-04
 ### Changed
 - Fixed exclude for `kubernetes_container` plugin ([PR152](https://github.com/observIQ/stanza-plugins/pull/152))

--- a/plugins/sap_hana.yaml
+++ b/plugins/sap_hana.yaml
@@ -3,11 +3,16 @@ version: 0.0.2
 title: SAP HANA
 description: Log parser for SAP HANA
 parameters:
-  - name: file_path
-    label: SAP HANA Database Trace Logs
-    description: The absolute path to the SAP HANA logs
+  - name: logs_directory
+    label: Logs directory for SAP HANA Database Trace Logs
+    description: The directory to the SAP HANA trace logs. No trailing slash should be included.
     type: string
-    default: "/usr/sap/*/HDB*/*/trace/*.trc"
+    default: "/usr/sap/*/HDB*/*/trace"
+  - name: file_name
+    label: File Name of SAP HANA Database Trace Logs
+    description: 'The file name of the SAP HANA trace log. This can be a glob pattern. Use "*.trc" to get all files with file extension of "trc". The files nameserver_history*.trc, nameserver*loads*.trc, nameserver*unloads*.trc, and nameserver*executed_staments*.trc are excluded from the logs directory and will not be parsed.'
+    type: string
+    default: "*.trc"
   - name: start_at
     label: Start At
     description: Start reading file from 'beginning' or 'end'
@@ -18,7 +23,8 @@ parameters:
     default: end
 
 # Set Defaults
-# {{$file_path := default "/usr/sap/*/HDB*/*/trace/*.trc" .file_path}}
+# {{$file_name := default "*.trc" .file_name}}
+# {{$logs_directory := default "/usr/sap/*/HDB*/*/trace" .logs_directory}}
 # {{$start_at := default "end" .start_at}}
 
 # Pipeline Template
@@ -26,9 +32,12 @@ pipeline:
   - id: sap_hana_input
     type: file_input
     include:
-      - {{ $file_path }}
+      - '{{ $logs_directory }}/{{ $file_name }}'
     exclude:
-      - '{{ $file_path }}nameserver_history*.trc'
+      - '{{ $logs_directory }}/nameserver_history*.trc'
+      - '{{ $logs_directory }}/nameserver*loads*.trc'
+      - '{{ $logs_directory }}/nameserver*unloads*.trc'
+      - '{{ $logs_directory }}/nameserver*executed_statements*.trc'
     multiline:
       line_start_pattern: '\[\d+\]{[^}]+}\[[^\/]+\/[^\]]+\] \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ [^ ]+ [^ ]+\s+[^ ]+ :'
     start_at: {{ $start_at }}
@@ -45,7 +54,6 @@ pipeline:
       layout: '%Y-%m-%d %H:%M:%S.%s'
     severity:
       parse_from: sap_severity
-      preserve_to: sap_severity
       mapping:
         debug: d
         info: i

--- a/plugins/sap_hana.yaml
+++ b/plugins/sap_hana.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: SAP HANA
 description: Log parser for SAP HANA
 parameters:
@@ -27,6 +27,8 @@ pipeline:
     type: file_input
     include:
       - {{ $file_path }}
+    exclude:
+      - '{{ $file_path }}nameserver_history*.trc'
     multiline:
       line_start_pattern: '\[\d+\]{[^}]+}\[[^\/]+\/[^\]]+\] \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ [^ ]+ [^ ]+\s+[^ ]+ :'
     start_at: {{ $start_at }}


### PR DESCRIPTION
Update sap_hana to exclude files that do not match parsing pattern for trace logs. In order to exclude the files we needed to know the directory path so we could append the file names to the path. To accomplish this I removed `file_path` and split it into two parameters.
- Remove `file_path` and `preserve_to` parameter
- Add `file_name` and `logs_directory` parameter
- Exclude `nameserver_history*.trc`, `nameserver*loads*.trc`, `nameserver*unloads*.trc`, and `nameserver*executed_statements*.trc` files