### PR TITLE
Fix Aerospike parse error. Remove preserve_to parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.33] - Unreleased
 ### Changed
-- Update `sap_hana` plugin ([PR151](https://github.com/observIQ/stanza-plugins/pull/151))
+- Update `aerospike` plugin ([PR156](https://github.com/observIQ/stanza-plugins/pull/156))  
+  - Update regex to handle `FAILED ASSERTION` severity.
+  - Remove `preserve_to` parameter
+- Update `sap_hana` plugin ([PR155](https://github.com/observIQ/stanza-plugins/pull/155))
   - Remove `file_path` and `preserve_to` parameter
   - Add `file_name` and `logs_directory` parameter
   - Exclude `nameserver_history*.trc`, `nameserver*loads*.trc`, `nameserver*unloads*.trc`, and `nameserver*executed_statements*.trc` files
+
 ## [0.0.32] - 2021-01-04
 ### Changed
 - Fixed exclude for `kubernetes_container` plugin ([PR152](https://github.com/observIQ/stanza-plugins/pull/152))

--- a/plugins/aerospike.yaml
+++ b/plugins/aerospike.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.4
+version: 0.0.5
 title: Aerospike
 description: Log parser for Aerospike
 parameters:
@@ -45,15 +45,15 @@ pipeline:
 
   - id: aerospike_general_parser
     type: regex_parser
-    regex: '^(?P<timestamp>[a-zA-z]+ \d{2} \d{4} \d{2}:\d{2}:\d{2} [A-Z]+): (?P<aerospike_severity>[A-Z]*) \((?P<context>[^\)]*)\): \((?P<source_file>[^:]*):(?P<source_location>[^:]*)\)\s*({(?P<namespace>[^}]*)} )?(?P<message>.*)'
+    regex: '^(?P<timestamp>[a-zA-z]+ \d{2} \d{4} \d{2}:\d{2}:\d{2} [A-Z]+): (?P<aerospike_severity>[A-Z]*( [A-Z]*)?) \((?P<context>[^\)]*)\): \((?P<source_file>[^:]*):(?P<source_location>[^:]*)\)\s*({(?P<namespace>[^}]*)} )?(?P<message>.*)'
     timestamp:
       parse_from: timestamp
       layout: '%b %d %Y %H:%M:%S %Z'
     severity:
       parse_from: aerospike_severity
-      preserve_to: aerospike_severity
       mapping:
         info: detail
+        critical: 'failed assertion'
     output: config_filter
 
   - id: config_filter


### PR DESCRIPTION
Update regex to correctly parse when severity level is `FAILED ASSERTION` and map as critical severity. Remove `aerospike_severity` field after parsing.
- Update regex to handle `FAILED ASSERTION` severity.
- Remove `preserve_to` parameter