### PR TITLE
Update nginx ingress add source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [0.0.33] - Unreleased
+## [0.0.34] - Unreleased
 ### Changed
+## [0.0.33] - 2021-01-07
+### Changed
+- Update `nginx_ingress` plugin ([PR158](https://github.com/observIQ/stanza-plugins/pull/158))
+  - Update `nginx_ingress` with source parameter
+  - Add default parameter to `log_format` parameter
 - Update `vmware_esxi` plugin ([PR157](https://github.com/observIQ/stanza-plugins/pull/157))
   - Add severity parser to parse priority field.
 - Update `aerospike` plugin ([PR156](https://github.com/observIQ/stanza-plugins/pull/156))  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ## [0.0.33] - 2021-01-07
 ### Changed
+- Update `nginx` plugin ([PR158](https://github.com/observIQ/stanza-plugins/pull/158))
+  - Add default parameter to `log_format` parameter
 - Update `nginx_ingress` plugin ([PR158](https://github.com/observIQ/stanza-plugins/pull/158))
   - Update `nginx_ingress` with source parameter
   - Add default parameter to `log_format` parameter

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 title: Nginx
 description: Log parser for Nginx
 supported_platforms: 
@@ -90,6 +90,7 @@ parameters:
     valid_values:
       - default
       - observiq
+    default: default
 
 # Set Defaults
 # {{$source := default "file" .source}}

--- a/plugins/nginx_ingress.yaml
+++ b/plugins/nginx_ingress.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 title: Nginx Ingress
 description: Log parser for Nginx Ingress for Kubernetes
 supported_platforms: 
@@ -58,6 +58,14 @@ parameters:
     valid_values:
       - default
       - observiq
+    default: default
+  - name: source
+    label: Log source
+    description: Where the logs are coming from
+    type: enum
+    valid_values:
+      - kubernetes
+    default: kubernetes
 
 # Set Defaults
 # {{$enable_access_log := default true .enable_access_log}}


### PR DESCRIPTION
Update `nginx_ingress` to add source parameter. This is required to add excludes to kubernetes plugins from ui. Set `log_format` to default as default.
- Update `nginx_ingress` with source parameter
- Add default parameter to `log_format` parameter