### PR TITLE
Update kubernetes container add log type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.34] - Unreleased
 ### Changed
+- Update `kubernetes_container` plugin ([PR159](https://github.com/observIQ/stanza-plugins/pull/159))
+  - Add log_type k8s.container to labels
+  - Exclude kube* pods
 ## [0.0.33] - 2021-01-07
 ### Changed
 - Update `nginx` plugin ([PR158](https://github.com/observIQ/stanza-plugins/pull/158))

--- a/plugins/kubernetes_container.yaml
+++ b/plugins/kubernetes_container.yaml
@@ -1,4 +1,4 @@
-version: 0.0.10
+version: 0.0.11
 title: Kubernetes Container
 id: kubernetes
 description: Log parser for Kubernetes
@@ -47,12 +47,13 @@ pipeline:
     include:
       - '/var/log/containers/{{ $pod_name }}-*_{{ $container_name }}-*.log'
     exclude:
-    {{ range $index, $element := .exclude }}
+      - '/var/log/containers/kube*'
+    # {{ range $index, $element := .exclude }}
       - {{ $element }}
-    {{ end }}
-
+    # {{ end }}
     start_at: '{{ $start_at }}'
     labels:
+      log_type: 'k8s.container'
       plugin_id: '{{ .id }}'
     resource:
       k8s.node.name: "EXPR(env('NODE_NAME'))"


### PR DESCRIPTION
In some instances we would capture kube logs in the container plugin. When splitting the kubernetes plugin we failed to add log type to kubernetes_container.
- Add log_type k8s.container to labels
- Exclude kube* pods