### PR TITLE
Update dockerswarm to fix time parser error and remove severity presreve_to parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update docker_swarm_parser parser timestamp layout to use space padded day. 
   - Remove the severity `preserve_to` parameter from dockerd_parser and containerd_parser
   - Change severity name on containerd_parser to containerd_severity
+  - Add pid field
 ## [0.0.34] - 2021-01-07
 ### Changed
 - Update `kubernetes_cluster` plugin ([PR160](https://github.com/observIQ/stanza-plugins/pull/160))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-## [0.0.34] - Unreleased
+## [0.0.35] - Unreleased
+### Changed
+- Update `dockerswarm` plugin ([PR161](https://github.com/observIQ/stanza-plugins/pull/161))
+  - Update docker_swarm_parser parser timestamp layout to use space padded day. 
+  - Remove `preserve_to` parameter from dockerd_parser and containerd_parser
+## [0.0.34] - 2021-01-07
 ### Changed
 - Update `kubernetes_cluster` plugin ([PR160](https://github.com/observIQ/stanza-plugins/pull/160))
   - Update `title` parameter value to Kubernetes Node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `dockerswarm` plugin ([PR161](https://github.com/observIQ/stanza-plugins/pull/161))
   - Update docker_swarm_parser parser timestamp layout to use space padded day. 
-  - Remove `preserve_to` parameter from dockerd_parser and containerd_parser
+  - Remove the severity `preserve_to` parameter from dockerd_parser and containerd_parser
+  - Change severity name on containerd_parser to containerd_severity
 ## [0.0.34] - 2021-01-07
 ### Changed
 - Update `kubernetes_cluster` plugin ([PR160](https://github.com/observIQ/stanza-plugins/pull/160))

--- a/plugins/docker_swarm.yaml
+++ b/plugins/docker_swarm.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: Docker Swarm
 description: Log parser for Docker Swarm
 parameters:
@@ -37,7 +37,7 @@ pipeline:
     regex: '^(?P<timestamp>[A-Za-z]*\s+\d+ \d+:\d+:\d+) (?P<host>[^ ]*) (?P<type>[^:]*): (?P<message>.*)'
     timestamp:
       parse_from: timestamp
-      layout: '%b %d %H:%M:%S'
+      layout: '%b %e %H:%M:%S'
     output: docker_swarm_router
 
   - id: docker_swarm_router
@@ -66,7 +66,6 @@ pipeline:
     regex: '^time="(?P<timestamp>[^"]*)" level=(?P<dockerd_severity>[^ ]*) msg=(?P<message>.*)'
     severity:
       parse_from: dockerd_severity
-      preserve_to: dockerd_severity
       mapping:
         warning: warn
     timestamp:
@@ -80,7 +79,6 @@ pipeline:
     regex: '^time="(?P<timestamp>[^"]*)" level=(?P<dockerd_severity>[^ ]*) msg=(?P<message>.*)'
     severity:
       parse_from: dockerd_severity
-      preserve_to: dockerd_severity
       mapping:
         warning: warn
     timestamp:

--- a/plugins/docker_swarm.yaml
+++ b/plugins/docker_swarm.yaml
@@ -76,9 +76,9 @@ pipeline:
   - id: containerd_parser
     type: regex_parser
     parse_from: message
-    regex: '^time="(?P<timestamp>[^"]*)" level=(?P<dockerd_severity>[^ ]*) msg=(?P<message>.*)'
+    regex: '^time="(?P<timestamp>[^"]*)" level=(?P<containerd_severity>[^ ]*) msg=(?P<message>.*)'
     severity:
-      parse_from: dockerd_severity
+      parse_from: containerd_severity
       mapping:
         warning: warn
     timestamp:

--- a/plugins/docker_swarm.yaml
+++ b/plugins/docker_swarm.yaml
@@ -51,11 +51,11 @@ pipeline:
         expr: '$.type matches "containerd"'
         labels:
           log_type: docker_swarm.containerd
-      - output: {{ .output }}
+      - output: type_parser
         expr: '$.type matches "kernel"'
         labels:
           log_type: docker_swarm.kernel
-      - output: {{ .output }}
+      - output: type_parser
         expr: '$.type matches "NetworkManager"'
         labels:
           log_type: docker_swarm.network_manager
@@ -71,7 +71,7 @@ pipeline:
     timestamp:
       parse_from: timestamp
       layout: '%Y-%m-%dT%H:%M:%S.%s%j'
-    output: {{ .output }}
+    output: type_parser
 
   - id: containerd_parser
     type: regex_parser
@@ -84,4 +84,11 @@ pipeline:
     timestamp:
       parse_from: timestamp
       layout: '%Y-%m-%dT%H:%M:%S.%s%j'
+    output: type_parser
+
+  - id: type_parser
+    type: regex_parser
+    parse_from: $record.type
+    if: '$record.type matches ".*\\[[^\\]]*\\]"'
+    regex: '(?P<type>.*)\[(?P<pid>[^\]]*)\]'
     output: {{ .output }}


### PR DESCRIPTION
When the day of the month was 1-9 the docker_swarm_parsers' timestamp would generate an error. No longer preserve the dockerd_severity and containerd_severity
- Update docker_swarm_parser parser timestamp layout to use space padded day. 
- Remove `preserve_to` parameter from dockerd_parser and containerd_parser
- Change severity name on containerd_parser to containerd_severity