### PR TITLE
Update kubernetes container add severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.35] - Unreleased
+- Update `kubernetes_container` plugin ([PR163](https://github.com/observIQ/stanza-plugins/pull/163))
+  - Add severity parser
+  - Move log field to message field
 - Update kubernetes_events plugin ([PR162](https://github.com/observIQ/stanza-plugins/pull/162))
   - Add missing INFO level cluster events
 ## [0.0.34] - 2021-01-07

--- a/plugins/kubernetes_container.yaml
+++ b/plugins/kubernetes_container.yaml
@@ -107,5 +107,5 @@ pipeline:
           to: "$labels.stream"
       - move:
           from: log
-          to: "$record"
+          to: "$record.message"
     output: {{ .output }}

--- a/plugins/kubernetes_container.yaml
+++ b/plugins/kubernetes_container.yaml
@@ -1,4 +1,4 @@
-version: 0.0.11
+version: 0.0.12
 title: Kubernetes Container
 id: kubernetes
 description: Log parser for Kubernetes
@@ -72,6 +72,12 @@ pipeline:
     type: regex_parser
     parse_from: $labels.file_name
     regex: '^(?P<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?P<namespace>[^_]+)_(?P<container_name>.+)-(?P<container_id>[a-z0-9]{64})\.log$'
+    severity:
+      parse_from: stream
+      preserve_to: stream
+      mapping:
+        error: stderr
+        info: stdout
 
   - id: resource_restructurer
     type: restructure


### PR DESCRIPTION
When the kubernetes plugin was split the severity parser was not added to kubernetes_container. Added severity parser to parse from stream field.
- Add severity parser
- Move log field to message field