### PR TITLE
Update nginx plugin to remove http_x_forwarded_for field from default log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update error and access `log_type` values to `nginx.ingress.error` and `nginx.ingress.access`
 - Update `nginx` plugin ([PR165](https://github.com/observIQ/stanza-plugins/pull/165))
   - Update default log format to remove http_x_forwarded_for field
+  - Update observiq log format to use json formatting and parsing
 - Update kubernetes_cluster plugin ([PR164](https://github.com/observIQ/stanza-plugins/pull/164))
   - Remove `container_log_path` parameter and hard code path `/var/log/containers/`
   - Move log field to message field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.35] - Unreleased
+- Update `nginx` plugin ([PR165](https://github.com/observIQ/stanza-plugins/pull/165))
+  - Update default log format to remove http_x_forwarded_for field
 - Update kubernetes_events plugin ([PR162](https://github.com/observIQ/stanza-plugins/pull/162))
   - Add missing INFO level cluster events
 ## [0.0.34] - 2021-01-07

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -78,14 +78,7 @@ parameters:
                     '"$http_referer" "$http_user_agent"';
 
       Observiq expects the following format. Remove any fields you do not wish to include, but do not remove the '|' separators. Do not reorder fields.
-      log_format observiq '$remote_addr|$remote_user|[$time_local]'
-                    '|"$request"|$status|$body_bytes_sent'
-                    '|"$http_referer"|"$http_user_agent"'
-                    '|$request_length|$request_time|$upstream_addr'
-                    '|$upstream_response_length|$upstream_response_time'
-                    '|$upstream_status|[$proxy_add_x_forwarded_for]'
-                    '|$bytes_sent|$time_iso8601|$upstream_connect_time'
-                    '|$upstream_header_time|';
+      log_format observiq '{"remote_addr":"$remote_addr","remote_user":"$remote_user","time_local":"$time_local","request":"$request","status":"$status","body_bytes_sent":"$body_bytes_sent","http_referer":"$http_referer","http_user_agent":"$http_user_agent","request_length":"$request_length","request_time":"$request_time","upstream_addr":"$upstream_addr","upstream_response_length":"$upstream_response_length","upstream_response_time":"$upstream_response_time","upstream_status":"$upstream_status","proxy_add_x_forwarded_for":"$proxy_add_x_forwarded_for","bytes_sent":"$bytes_sent","time_iso8601":"$time_iso8601","upstream_connect_time":"$upstream_connect_time","upstream_header_time":"$upstream_header_time","http_x_forwarded_for":"$http_x_forwarded_for"}';
     type: enum
     valid_values:
       - default
@@ -117,7 +110,7 @@ pipeline:
     routes:
       # {{ if $enable_access_log }}
       - expr: "$labels.stream == 'stdout'"
-        output: access_regex_parser
+        output: access_parser
         labels:
           log_type: 'nginx.access'
           plugin_id: '{{ .id }}'
@@ -140,7 +133,7 @@ pipeline:
     labels:
       log_type: 'nginx.access'
       plugin_id: '{{ .id }}'
-    output: access_regex_parser
+    output: access_parser
   # {{ end }}
 
   # {{ if and $enable_error_log (eq $source "file") }}
@@ -158,7 +151,7 @@ pipeline:
   # {{ end }}
 
   # {{ if eq $log_format "default" }}
-  - id: access_regex_parser
+  - id: access_parser
     type: regex_parser
     regex: '^(?P<remote_addr>[^ ]*) - (?P<remote_user>[^ ]*) \[(?P<time_local>[^\]]*)\] "(?P<method>\S+) +(?P<path>[^\"]*?)\S*" (?P<status>[^ ]*) (?P<body_bytes_sent>[^ ]*) "(?P<http_referer>[^\"]*)" "(?P<http_user_agent>[^\"]*)"'
     timestamp:
@@ -176,9 +169,8 @@ pipeline:
   # {{ end }}
 
   # {{ if eq $log_format "observiq" }}
-  - id: access_regex_parser
-    type: regex_parser
-    regex: '(?P<remote_addr>[^\|]*)\|(?P<remote_user>[^\|]*)\|\[(?P<time_local>[^\]]+)\]\|"(?P<method>[A-Z]*)( )?(?P<path>\S*)( )?[^\"]*"\|(?P<status>[^\|]*)\|(?P<body_bytes_sent>[^\|]*)\|"(?P<http_referer>\S*)"\|"(?P<http_user_agent>[^"]*)"\|(?P<request_length>[^\|]*)\|(?P<request_time>[^\|]*)\|(?P<upstream_addr>[^\|]*)\|(?P<upstream_response_length>[^\|]*)\|(?P<upstream_response_time>[^\|]*)\|(?P<upstream_status>[^\|]*)\|\[(?P<proxy_add_x_forwarded_for>[^\]]*)\]\|(?P<bytes_sent>[^\|]*)\|(?P<time_iso8601>[^\|]*)\|(?P<upstream_connect_time>[^\|]*)\|(?P<upstream_header_time>[^\|]*)\|'
+  - id: access_parser
+    type: json_parser
     timestamp:
       parse_from: time_local
       layout: '%d/%b/%Y:%H:%M:%S %z'

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 title: Nginx
 description: Log parser for Nginx
 supported_platforms: 
@@ -160,7 +160,7 @@ pipeline:
   # {{ if eq $log_format "default" }}
   - id: access_regex_parser
     type: regex_parser
-    regex: '^(?P<remote_addr>[^ ]*) - (?P<remote_user>[^ ]*) \[(?P<time_local>[^\]]*)\] "(?P<method>\S+)(?: +(?P<path>[^\"]*?)(?: +\S*)?)?" (?P<status>[^ ]*) (?P<body_bytes_sent>[^ ]*)(?: "(?P<http_referer>[^\"]*)" "(?P<http_user_agent>[^\"]*)"(?:\s+(?P<http_x_forwarded_for>[^ ]+))?)?$'
+    regex: '^(?P<remote_addr>[^ ]*) - (?P<remote_user>[^ ]*) \[(?P<time_local>[^\]]*)\] "(?P<method>\S+) +(?P<path>[^\"]*?)\S*" (?P<status>[^ ]*) (?P<body_bytes_sent>[^ ]*) "(?P<http_referer>[^\"]*)" "(?P<http_user_agent>[^\"]*)"'
     timestamp:
       parse_from: time_local
       layout: '%d/%b/%Y:%H:%M:%S %z'

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -77,7 +77,7 @@ parameters:
                     '"$request" $status $body_bytes_sent '
                     '"$http_referer" "$http_user_agent"';
 
-      Observiq expects the following format. Remove any fields you do not wish to include, but do not remove the '|' separators. Do not reorder fields.
+      Observiq expects the following format. This format will generate a json log entry. This log_format can be modified to meet your requirements as long as key names do not change and it is valid json.
       log_format observiq '{"remote_addr":"$remote_addr","remote_user":"$remote_user","time_local":"$time_local","request":"$request","status":"$status","body_bytes_sent":"$body_bytes_sent","http_referer":"$http_referer","http_user_agent":"$http_user_agent","request_length":"$request_length","request_time":"$request_time","upstream_addr":"$upstream_addr","upstream_response_length":"$upstream_response_length","upstream_response_time":"$upstream_response_time","upstream_status":"$upstream_status","proxy_add_x_forwarded_for":"$proxy_add_x_forwarded_for","bytes_sent":"$bytes_sent","time_iso8601":"$time_iso8601","upstream_connect_time":"$upstream_connect_time","upstream_header_time":"$upstream_header_time","http_x_forwarded_for":"$http_x_forwarded_for"}';
     type: enum
     valid_values:


### PR DESCRIPTION
NGINX does not have the http_x_forwarded_for field in default configuration.
- Update default log format to remove http_x_forwarded_for field
- Update observiq log format to use json formatting and parsing