### PR TITLE
Update nginx Update error and access log_type values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.35] - Unreleased
+- Update `nginx_ingress` plugin ([PR166](https://github.com/observIQ/stanza-plugins/pull/166))
+  - Update error and access `log_type` values to `nginx.ingress.error` and `nginx.ingress.access`
 - Update kubernetes_cluster plugin ([PR164](https://github.com/observIQ/stanza-plugins/pull/164))
   - Remove `container_log_path` parameter and hard code path `/var/log/containers/`
   - Move log field to message field

--- a/plugins/nginx_ingress.yaml
+++ b/plugins/nginx_ingress.yaml
@@ -1,4 +1,4 @@
-version: 0.0.2
+version: 0.0.3
 title: Nginx Ingress
 description: Log parser for Nginx Ingress for Kubernetes
 supported_platforms: 
@@ -92,14 +92,14 @@ pipeline:
       - expr: "$labels.stream == 'stdout'"
         output: access_regex_parser
         labels:
-          log_type: 'nginx.access'
+          log_type: 'nginx.ingress.access'
           plugin_id: '{{ .id }}'
       # {{ end }}
       # {{ if $enable_error_log }}
       - expr: '$labels.stream == "stderr" and $record.message matches "\\d{4}\\/\\d{2}\\/\\d{2} \\d{2}:\\d{2}:\\d{2} \\[\\w+\\] \\d+\\.\\d+: "'
         output: error_regex_parser
         labels:
-          log_type: 'nginx.error'
+          log_type: 'nginx.ingress.error'
           plugin_id: '{{ .id }}'
       - expr: '$labels.stream == "stderr"'
         output: ingress_controller_regex_parser


### PR DESCRIPTION
Update `log_type` for both error and access logs to be consistent with `nginx.ingress.controller` and to differentiate between `nginx` plugin.
- Update error and access `log_type` values to `nginx.ingress.error` and `nginx.ingress.access`