### PR TITLE
Update redis to remove preserve_to from severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.35] - Unreleased
+- Update `redis` plugin ([PR167](https://github.com/observIQ/stanza-plugins/pull/167))  
+  - Remove `preserve_to` parameter from severity
 - Update kubernetes_cluster plugin ([PR164](https://github.com/observIQ/stanza-plugins/pull/164))
   - Remove `container_log_path` parameter and hard code path `/var/log/containers/`
   - Move log field to message field

--- a/plugins/redis.yaml
+++ b/plugins/redis.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: Redis
 description: Log parser for Redis
 parameters:
@@ -43,7 +43,6 @@ pipeline:
       layout: '%d %b %H:%M:%S.%s'
     severity:
       parse_from: redis_severity
-      preserve_to: redis_severity
       mapping:
         warning: ' # '
         info: ' - '


### PR DESCRIPTION
- Remove `preserve_to` parameter from severity