### PR TITLE
Update rabbitmq to remove preserve_to from severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.35] - Unreleased
+- Update `rabbitmq` plugin ([PR168](https://github.com/observIQ/stanza-plugins/pull/168))  
+  - Remove `preserve_to` parameter from severity
 - Update kubernetes_cluster plugin ([PR164](https://github.com/observIQ/stanza-plugins/pull/164))
   - Remove `container_log_path` parameter and hard code path `/var/log/containers/`
   - Move log field to message field

--- a/plugins/rabbitmq.yaml
+++ b/plugins/rabbitmq.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: RabbitMQ
 description: Log parser for RabbitMQ
 parameters:
@@ -43,5 +43,4 @@ pipeline:
       layout: '%Y-%m-%d %H:%M:%S.%s'
     severity:
       parse_from: rabbitmq_severity
-      preserve_to: rabbitmq_severity
     output: {{.output}}


### PR DESCRIPTION
- Remove `preserve_to` parameter from severity