### PR TITLE
Update hbase to remove preserve_to from severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.35] - Unreleased
+- Update `hbase` plugin ([PR169](https://github.com/observIQ/stanza-plugins/pull/169))
+  - Remove `preserve_to` parameter from severity
 - Update kubernetes_cluster plugin ([PR164](https://github.com/observIQ/stanza-plugins/pull/164))
   - Remove `container_log_path` parameter and hard code path `/var/log/containers/`
   - Move log field to message field

--- a/plugins/hbase.yaml
+++ b/plugins/hbase.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.4
+version: 0.0.5
 title: Apache HBase
 description: Log parser for Apache HBase
 parameters:
@@ -83,7 +83,6 @@ pipeline:
       layout: '%Y-%m-%d %H:%M:%S'
     severity:
       parse_from: hbase_severity
-      preserve_to: hbase_severity
       mapping:
         warning: warn
         emergency: fatal
@@ -120,7 +119,6 @@ pipeline:
       layout: '%Y-%m-%d %H:%M:%S'
     severity:
       parse_from: hbase_severity
-      preserve_to: hbase_severity
       mapping:
         warning: warn
         emergency: fatal
@@ -157,7 +155,6 @@ pipeline:
       layout: '%Y-%m-%d %H:%M:%S'
     severity:
       parse_from: hbase_severity
-      preserve_to: hbase_severity
       mapping:
         warning: warn
         emergency: fatal


### PR DESCRIPTION
- Remove `preserve_to` parameter from severity