### PR TITLE
Update couchbase to add severity parser to internal access and access log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.35] - Unreleased
 - Update `couchbase` plugin ([PR170](https://github.com/observIQ/stanza-plugins/pull/170))
-  - Add severity parser to internal access and access log
+  - Rename name `http_status_code` field to `status`
+  - Add severity parser to internal access and access logs
 - Update kubernetes_cluster plugin ([PR164](https://github.com/observIQ/stanza-plugins/pull/164))
   - Remove `container_log_path` parameter and hard code path `/var/log/containers/`
   - Move log field to message field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.35] - Unreleased
+- Update `couchbase` plugin ([PR170](https://github.com/observIQ/stanza-plugins/pull/170))
+  - Add severity parser to internal access and access log
 - Update kubernetes_cluster plugin ([PR164](https://github.com/observIQ/stanza-plugins/pull/164))
   - Remove `container_log_path` parameter and hard code path `/var/log/containers/`
   - Move log field to message field

--- a/plugins/couchbase.yaml
+++ b/plugins/couchbase.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.3
+version: 0.0.4
 title: Couchbase
 description: Log parser for Couchbase
 parameters:
@@ -211,10 +211,19 @@ pipeline:
 
   - id: couchbase_http_access_parser
     type: regex_parser
-    regex: '(?P<ip_address>\d+.\d+.\d+.\d+)\s+(?P<user_identifier>.*) \[(?P<timestamp>\d{2}\/\w+\/\d{4}:\d{2}:\d{2}:\d{2} -\d{4})\] \\*"(?P<request_line>[^"]*)\\*" (?P<http_status_code>\d{3}) (?P<size>\d*) *-*(?P<message>.*)'
+    regex: '(?P<ip_address>\d+.\d+.\d+.\d+)\s+(?P<user_identifier>.*) \[(?P<timestamp>\d{2}\/\w+\/\d{4}:\d{2}:\d{2}:\d{2} -\d{4})\] \\*"(?P<request_line>[^"]*)\\*" (?P<status>\d{3}) (?P<size>\d*) *-*(?P<message>.*)'
     timestamp:
       parse_from: timestamp
       layout: '%d/%b/%Y:%H:%M:%S %z'
+    severity:
+      parse_from: status
+      preset: none
+      preserve_to: status
+      mapping:
+        info: 2xx
+        notice: 3xx
+        warning: 4xx
+        error: 5xx
     output: {{.output}}
 # {{ end }}
 
@@ -231,10 +240,19 @@ pipeline:
 
   - id: couchbase_http_access_internal_parser
     type: regex_parser
-    regex: '(?P<ip_address>\d+.\d+.\d+.\d+)\s+(?P<user_identifier>.*) \[(?P<timestamp>\d{2}\/\w+\/\d{4}:\d{2}:\d{2}:\d{2} -\d{4})\] \\*"(?P<request_line>[^"]*)\\*" (?P<http_status_code>\d{3}) (?P<size>\d*) *-*(?P<message>.*)'
+    regex: '(?P<ip_address>\d+.\d+.\d+.\d+)\s+(?P<user_identifier>.*) \[(?P<timestamp>\d{2}\/\w+\/\d{4}:\d{2}:\d{2}:\d{2} -\d{4})\] \\*"(?P<request_line>[^"]*)\\*" (?P<status>\d{3}) (?P<size>\d*) *-*(?P<message>.*)'
     timestamp:
       parse_from: timestamp
       layout: '%d/%b/%Y:%H:%M:%S %z'
+    severity:
+      parse_from: status
+      preset: none
+      preserve_to: status
+      mapping:
+        info: 2xx
+        notice: 3xx
+        warning: 4xx
+        error: 5xx
     output: {{.output}}
 # {{ end }}
 


### PR DESCRIPTION
Rename name `http_status_code` field to `status` to better match other plugins like `apache_http`. Add severity to internal access and access logs using `status` field
- Rename name `http_status_code` field to `status`
- Add severity parser to internal access and access logs