### PR TITLE
Update aerospike to remove enable_general_log parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.35] - Unreleased
+- Update `aerospike` plugin ([PR171](https://github.com/observIQ/stanza-plugins/pull/171))
+  - Remove `enable_general_log` parameter
+  - Change log_type to aerospike
 - Update `couchbase` plugin ([PR170](https://github.com/observIQ/stanza-plugins/pull/170))
   - Rename name `http_status_code` field to `status`
 - Update `hbase` plugin ([PR169](https://github.com/observIQ/stanza-plugins/pull/169))

--- a/plugins/aerospike.yaml
+++ b/plugins/aerospike.yaml
@@ -1,21 +1,13 @@
 # Plugin Info
-version: 0.0.5
+version: 0.0.6
 title: Aerospike
 description: Log parser for Aerospike
 parameters:
-  - name: enable_general_log
-    label: General Logs
-    description: Enable to collect general Aerospike logs
-    type: bool
-    default: true
   - name: general_log_path
     label: General Logs Path
     description: The absolute path to the general Aerospike logs
     type: string
     default: "/var/log/aerospike/aerospike.log"
-    relevant_if:
-      enable_general_log:
-        equals: true
   - name: start_at
     label: Start At
     description: Start reading file from 'beginning' or 'end'
@@ -39,7 +31,7 @@ pipeline:
       - {{ $general_log_path }}
     start_at: {{ $start_at }}
     labels:
-      log_type: aerospike.general
+      log_type: aerospike
       plugin_id: {{ .id }}
     output: aerospike_general_parser
 


### PR DESCRIPTION
Remove enable_general_log parameter as it is no longer needed after telemetry log was removed. Rename log_type to just aerospike as there is only one log_type in plugin now. 
- Remove `enable_general_log` parameter
- Change log_type to aerospike