### PR TITLE
Update pgbouncer to remove * from file_path defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.35] - Unreleased
+- Update `pgbouncer` plugin ([PR172](https://github.com/observIQ/stanza-plugins/pull/172))
+  - Remove `*` from `file_path` parameter defaults
 - Update `couchbase` plugin ([PR170](https://github.com/observIQ/stanza-plugins/pull/170))
   - Rename name `http_status_code` field to `status`
 - Update `hbase` plugin ([PR169](https://github.com/observIQ/stanza-plugins/pull/169))

--- a/plugins/pgbouncer.yaml
+++ b/plugins/pgbouncer.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.2
+version: 0.0.3
 title: PgBouncer
 description: Log parser for PgBouncer
 parameters:
@@ -7,7 +7,7 @@ parameters:
     label: PgBouncer Logs Path
     description: The absolute path to the PgBouncer logs
     type: string
-    default: "/var/log/pgbouncer/pgbouncer.log*"
+    default: "/var/log/pgbouncer/pgbouncer.log"
   - name: start_at
     label: Start At
     description: Start reading file from 'beginning' or 'end'
@@ -18,7 +18,7 @@ parameters:
     default: end
 
 # Set Defaults
-# {{$file_path := default "/var/log/pgbouncer/pgbouncer.log*" .file_path}}
+# {{$file_path := default "/var/log/pgbouncer/pgbouncer.log" .file_path}}
 # {{$start_at := default "end" .start_at}}
 
 # Pipeline Template


### PR DESCRIPTION
PGbouncer will gzip logs on rotation by default. With the `*` in the filepath we would try to parse the gzip files.
- Remove `*` from `file_path` parameter defaults