### PR TITLE
Update nginx_ingress observiq log_format to be JSON format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.35] - Unreleased
+- Update `nginx_ingress` plugin ([PR173](https://github.com/observIQ/stanza-plugins/pull/173))
+  - Update observiq log format to be JSON format
 - Update `aerospike` plugin ([PR171](https://github.com/observIQ/stanza-plugins/pull/171))
   - Remove `enable_general_log` parameter
   - Change log_type to aerospike

--- a/plugins/nginx_ingress.yaml
+++ b/plugins/nginx_ingress.yaml
@@ -46,14 +46,8 @@ parameters:
                     '$request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr '
                     '$upstream_response_length $upstream_response_time $upstream_status $req_id';
       
-      Observiq expects the following format. Remove any fields you do not wish to include, but do not remove the '|' separators. Do not reorder fields.
-      log_format observiq
-                    '$remote_addr|$remote_user|[$time_local]|"$request"'
-                    '|$status|$body_bytes_sent|"$http_referer"|"$http_user_agent"'
-                    '|$request_length|$request_time|[$proxy_upstream_name]|[$proxy_alternative_upstream_name]|$upstream_addr'
-                    '|$upstream_response_length|$upstream_response_time|$upstream_status|$req_id'
-                    '|[$proxy_add_x_forwarded_for]|$bytes_sent|$time_iso8601|$upstream_connect_time|$upstream_header_time'
-                    '|$namespace|$ingress_name|$service_name|$service_port|';
+      Observiq expects the following format. This format will generate a json log entry. This log_format can be modified to meet your requirements as long as key names do not change and it is valid json.
+      log-format-upstream: '{"remote_addr":"$remote_addr","remote_user":"$remote_user","time_local":"$time_local","request":"$request","status":"$status","body_bytes_sent":"$body_bytes_sent","http_referer":"$http_referer","http_user_agent":"$http_user_agent","request_length":"$request_length","request_time":"$request_time","proxy_upstream_name":"$proxy_upstream_name","proxy_alternative_upstream_name":"$proxy_alternative_upstream_name","upstream_addr":"$upstream_addr","upstream_response_length":"$upstream_response_length","upstream_response_time":"$upstream_response_time","upstream_status":"$upstream_status","req_id":"$req_id","proxy_add_x_forwarded_for":"$proxy_add_x_forwarded_for","bytes_sent":"$bytes_sent","time_iso8601":"$time_iso8601","upstream_connect_time":"$upstream_connect_time","upstream_header_time":"$upstream_header_time","namespace":"$namespace","ingress_name":"$ingress_name","service_name":"$service_name","service_port":"$service_port"}'
     type: enum
     valid_values:
       - default
@@ -90,7 +84,7 @@ pipeline:
     routes:
       # {{ if $enable_access_log }}
       - expr: "$labels.stream == 'stdout'"
-        output: access_regex_parser
+        output: access_parser
         labels:
           log_type: 'nginx.ingress.access'
           plugin_id: '{{ .id }}'
@@ -110,7 +104,7 @@ pipeline:
 
   # {{ if $enable_access_log }}
     # {{ if eq $log_format "default" }}
-  - id: access_regex_parser
+  - id: access_parser
     type: regex_parser
     regex: '(?P<remote_addr>\S+) - (?P<remote_user>\S+) \[(?P<time_local>[^\]]+)\] "(?P<method>[A-Z]+) (?P<path>\S+) [^\"]+" (?P<status>\d+) (?P<body_bytes_sent>\d+) "(?P<http_referer>\S+)" "(?P<http_user_agent>[^"]+)" (?P<request_length>\d+) (?P<request_time>[\d\.]+) \[(?P<proxy_upstream_name>[^\]]*)\] \[(?P<proxy_alternative_upstream_name>\s*)\] (?P<upstream_addr>\S+) (?P<upstream_response_length>[\d-]+) (?P<upstream_response_time>[\d\.-]+) (?P<upstream_status>[\d-]+) (?P<request_id>[a-z0-9]+)'
     timestamp:
@@ -128,9 +122,8 @@ pipeline:
     # {{ end }}
 
     # {{ if eq $log_format "observiq" }}
-  - id: access_regex_parser
-    type: regex_parser
-    regex: '(?P<remote_addr>[^\|]*)\|(?P<remote_user>[^\|]*)\|\[(?P<time_local>[^\]]*)\]\|"(?P<method>[A-Z]*)( )?(?P<path>\S*)( )?[^\"]*"\|(?P<status>\d*)\|(?P<body_bytes_sent>\d*)\|"(?P<http_referer>\S*)"\|"(?P<http_user_agent>[^"]*)"\|(?P<request_length>[^\|]*)\|(?P<request_time>[^\|]*)\|\[(?P<proxy_upstream_name>[^\]]*)\]\|\[(?P<proxy_alternative_upstream_name>[^\]]*)\]\|(?P<upstream_addr>[^\|]*)\|(?P<upstream_response_length>[^\|]*)\|(?P<upstream_response_time>[^\|]*)\|(?P<upstream_status>[^\|]*)\|(?P<request_id>[^\|]*)\|\[(?P<proxy_add_x_forwarded_for>[^\]]*)\]\|(?P<bytes_sent>[^\|]*)\|(?P<time_iso8601>[^\|]*)\|(?P<upstream_connect_time>[^\|]*)\|(?P<upstream_header_time>[^\|]*)\|(?P<service_namespace>[^\|]*)\|(?P<service_ingress_name>[^\|]*)\|(?P<service_name>[^\|]*)\|(?P<service_port>[^\|]*)\|'
+  - id: access_parser
+    type: json_parser
     timestamp:
       parse_from: time_local
       layout: '%d/%b/%Y:%H:%M:%S %z'


### PR DESCRIPTION
Updating our default spec to use JSON formatting. This removes the complexity associated with regex and reduces chances of errors if a field is removed. It will still work as long as it remains valid JSON.
- Update observiq log format to be JSON format