### PR TITLE
Update observiq agent log types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.36] - Unreleased
 ### Changed
+- Update `observiq_agent` plugin ([PR175](https://github.com/observIQ/stanza-plugins/pull/175))
+  - Add log_type_router to add log_type `observiq.agent.manager` and `observiq.agent.launcher`
 ## [0.0.35] - 2021-01-11
 ### Changed
 - Update `nginx_ingress` plugin 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `observiq_agent` plugin ([PR175](https://github.com/observIQ/stanza-plugins/pull/175))
   - Add log_type_router to add log_type `observiq.agent.manager` and `observiq.agent.launcher`
+  - Add metadata to add log_type `observiq.agent.logagent`
 ## [0.0.35] - 2021-01-11
 ### Changed
 - Update `nginx_ingress` plugin 

--- a/plugins/observiq_agent.yaml
+++ b/plugins/observiq_agent.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 title: observIQ Agent
 description: Agent logs for the observIQ Agent
 parameters:
@@ -10,14 +10,16 @@ parameters:
       - beginning
       - end
     default: end
+# Set Defaults
+# {{$start_at := default "end" .start_at}}
+# Pipeline Template
 pipeline:
-
   - id: log_reader
     type: file_input
     include:
       - log/manager.log
       - log/launcher.log
-    start_at: {{ or .start_at "end" }}
+    start_at: {{ $start_at }}
     labels:
       log_type: observiq.agent
       plugin_id: {{ .id }}
@@ -32,6 +34,19 @@ pipeline:
       layout_type: gotime
       layout: '2006-01-02T15:04:05.000-0700'
 
+  - id: log_type_router
+    type: router
+    default: log_restructure
+    routes:
+      - output: log_restructure
+        expr: '$labels.file_name == "manager.log"'
+        labels:
+          log_type: observiq.agent.manager
+      - output: log_restructure
+        expr: '$labels.file_name == "launcher.log"'
+        labels:
+          log_type: observiq.agent.launcher
+
   - id: log_restructure
     type: restructure
     ops:
@@ -42,4 +57,8 @@ pipeline:
 
   - id: stanza_log
     type: stanza_input
+
+  - type: metadata
+    labels:
+      log_type: observiq.agent.logagent
     output: {{ .output }}


### PR DESCRIPTION
- Add log_type_router to add log_type `observiq.agent.manager` and `observiq.agent.launcher`
- Add metadata to add log_type `observiq.agent.logagent`