### PR TITLE
Update kubernetes_container move from log to move to root of record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.36] - Unreleased
 ### Changed
+- Update `kubernetes_container` plugin ([PR180](https://github.com/observIQ/stanza-plugins/pull/180))
+  - Change move from `log` field back to `$record`
 ## [0.0.35] - 2021-01-11
 ### Changed
 - Update `nginx_ingress` plugin 

--- a/plugins/kubernetes_container.yaml
+++ b/plugins/kubernetes_container.yaml
@@ -1,4 +1,4 @@
-version: 0.0.12
+version: 0.0.13
 title: Kubernetes Container
 id: kubernetes
 description: Log parser for Kubernetes
@@ -107,5 +107,5 @@ pipeline:
           to: "$labels.stream"
       - move:
           from: log
-          to: "$record.message"
+          to: "$record"
     output: {{ .output }}


### PR DESCRIPTION
Last update changed the move of `log` field to `$record.message` field. This change broke support for kuberenetes input based plugins. Reverting the change.
- Change move from `log` field back to `$record`