### PR TITLE
Add Sync, RELOAD, FailedBinding to severity mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `kubernetes_container` plugin ([PR180](https://github.com/observIQ/stanza-plugins/pull/180))
   - Change move from `log` field back to `$record`
+- Update 'kubernetes_events' plugin ([PR181](https://github.com/observIQ/stanza-plugins/pull/181/files))
+  - Add RELOAD, Sync, FailedBinding severity mappings
 ## [0.0.35] - 2021-01-11
 ### Changed
 - Update `nginx_ingress` plugin 

--- a/plugins/kubernetes_events.yaml
+++ b/plugins/kubernetes_events.yaml
@@ -67,6 +67,7 @@ pipeline:
         - Pulled
         - Pulling
         - RegisteredNode
+        - RELOAD
         - SandboxChanged
         - ScalingReplicaSet
         - Scheduled
@@ -75,6 +76,7 @@ pipeline:
         - SuccessfulAttachVolume
         - SuccessfulCreate
         - SuccessfulMountVolume
+        - Sync
         - LeaderElection
         - Provisioning
         - ProvisioningSucceeded
@@ -85,6 +87,7 @@ pipeline:
         - ContainerGCFailed
         - Evicted
         - ExceededGracePeriod
+        - FailedBinding
         - FailedCreatePodSandBox
         - FailedKillPod
         - FailedNodeAllocatableEnforcement


### PR DESCRIPTION
Added some missing events

```
Sync | Scheduled for sync
RELOAD | NGINX reload triggered due to a change in configuration
FailedBinding | no persistent volumes available for this claim and no storage class is set
```

![Screen Shot 2021-01-13 at 9 49 40 AM](https://user-images.githubusercontent.com/23043836/104467747-aeb3e000-5584-11eb-9351-4cab7863e0c9.png)