### PR TITLE
Update syslog protocol names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.38] - Unreleased
 ### Changed
+- Update `syslog` plugin ([PR187](https://github.com/observIQ/stanza-plugins/pull/18))
+  - Update `protocol` parameter valid values field to `rfc5424 (IETF)` and `rfc3164 (BSD)`
 ## [0.0.37] - 2021-01-14
 ### Changed
 - Update `nginx` plugin ([PR184](https://github.com/observIQ/stanza-plugins/pull/184))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.38] - Unreleased
 ### Changed
-- Update `syslog` plugin ([PR187](https://github.com/observIQ/stanza-plugins/pull/18))
+- Update `syslog` plugin ([PR187](https://github.com/observIQ/stanza-plugins/pull/187))
   - Update `protocol` parameter valid values field to `rfc5424 (IETF)` and `rfc3164 (BSD)`
   - Update `listen_address` default to 0.0.0.0:514
 ## [0.0.37] - 2021-01-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `syslog` plugin ([PR187](https://github.com/observIQ/stanza-plugins/pull/18))
   - Update `protocol` parameter valid values field to `rfc5424 (IETF)` and `rfc3164 (BSD)`
+  - Update `listen_address` default to 0.0.0.0:514
 ## [0.0.37] - 2021-01-14
 ### Changed
 - Update `nginx` plugin ([PR184](https://github.com/observIQ/stanza-plugins/pull/184))

--- a/plugins/syslog.yaml
+++ b/plugins/syslog.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.2
+version: 0.0.3
 title: Syslog
 description: Log parser for Syslog
 parameters:
@@ -7,7 +7,7 @@ parameters:
     label: Listen Address
     description: A syslog address of the form `<ip>:<port>`
     type: string
-    default: ":514"
+    default: "0.0.0.0:514"
   - name: connection_type
     label: Connection Type
     description: The type of syslog connection (`udp` or `tcp`)
@@ -21,9 +21,9 @@ parameters:
     description: The protocol of received syslog messages (`rfc3164` or `rfc5424`)
     type: enum
     valid_values:
-      - rfc3164
-      - rfc5424
-    default: rfc5424
+      - rfc3164 (BSD)
+      - rfc5424 (IETF)
+    default: rfc5424 (IETF)
 
 # Set Defaults
 # {{$listen_address := default "0.0.0.0:514" .listen_address}}


### PR DESCRIPTION
- Update `protocol` parameter valid values field to `rfc5424 (IETF)` and `rfc3164 (BSD)`
- Update `listen_address` default to 0.0.0.0:514