### PR TITLE
Update kubernetes_cluster plugin to parse glogs format if matches pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `kubernetes_events` plugin ([PR186](https://github.com/observIQ/stanza-plugins/pull/186))
   - Add SuccessfulDelete to info severity
+- Update `kubernetes_node` plugin ([PR188](https://github.com/observIQ/stanza-plugins/pull/188))
+  - Add router to route logs to glogs format parser if it matches pattern
 ## [0.0.37] - 2021-01-14
 ### Changed
 - Update `nginx` plugin ([PR184](https://github.com/observIQ/stanza-plugins/pull/184))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.38] - Unreleased
 ### Changed
+- Update `observiq_agent` plugin ([PR189](https://github.com/observIQ/stanza-plugins/pull/189))
+  - Remove `preserve` field as it has been removed from Stanza in favor of `preserve_to`
+- Update `bindplane_agent` plugin ([PR189](https://github.com/observIQ/stanza-plugins/pull/189))
+  - Remove `preserve` field as it has been removed from Stanza in favor of `preserve_to`
 - Update `kubernetes_node` plugin ([PR188](https://github.com/observIQ/stanza-plugins/pull/188))
   - Add router to route logs to glogs format parser if it matches pattern
   - Update label `resource.container.name` to `resource.k8s.container.name`
@@ -15,10 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update `listen_address` default to 0.0.0.0:514
 - Update `kubernetes_events` plugin ([PR186](https://github.com/observIQ/stanza-plugins/pull/186))
   - Add SuccessfulDelete to info severity
-- Update `observiq_agent` plugin ([PR189](https://github.com/observIQ/stanza-plugins/pull/189))
-  - Remove `preserve` field as it has been removed from Stanza in favor of `preserve_to`
-- Update `bindplane_agent` plugin ([PR189](https://github.com/observIQ/stanza-plugins/pull/189))
-  - Remove `preserve` field as it has been removed from Stanza in favor of `preserve_to`
 ## [0.0.37] - 2021-01-14
 ### Changed
 - Update `nginx` plugin ([PR184](https://github.com/observIQ/stanza-plugins/pull/184))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `kubernetes_node` plugin ([PR188](https://github.com/observIQ/stanza-plugins/pull/188))
   - Add router to route logs to glogs format parser if it matches pattern
+  - Update label `resource.container.name` to `resource.k8s.container.name`
+  - Update label `resource.container.id` to `resource.k8s.container.id`
+  - Update `add_labels_router` to point to correct label name `$labels["k8s-pod/component"]`
 - Update `syslog` plugin ([PR187](https://github.com/observIQ/stanza-plugins/pull/187))
   - Update `protocol` parameter valid values field to `rfc5424 (IETF)` and `rfc3164 (BSD)`
   - Update `listen_address` default to 0.0.0.0:514

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.38] - Unreleased
 ### Changed
+- Update `kubernetes_node` plugin ([PR188](https://github.com/observIQ/stanza-plugins/pull/188))
+  - Add router to route logs to glogs format parser if it matches pattern
 - Update `syslog` plugin ([PR187](https://github.com/observIQ/stanza-plugins/pull/187))
   - Update `protocol` parameter valid values field to `rfc5424 (IETF)` and `rfc3164 (BSD)`
   - Update `listen_address` default to 0.0.0.0:514
 - Update `kubernetes_events` plugin ([PR186](https://github.com/observIQ/stanza-plugins/pull/186))
   - Add SuccessfulDelete to info severity
-- Update `kubernetes_node` plugin ([PR188](https://github.com/observIQ/stanza-plugins/pull/188))
-  - Add router to route logs to glogs format parser if it matches pattern
 ## [0.0.37] - 2021-01-14
 ### Changed
 - Update `nginx` plugin ([PR184](https://github.com/observIQ/stanza-plugins/pull/184))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update label `resource.container.name` to `resource.k8s.container.name`
   - Update label `resource.container.id` to `resource.k8s.container.id`
   - Update `add_labels_router` to point to correct label name `$labels["k8s-pod/component"]`
+  - Rename `source` field to `src` and parse `src_line`
 - Update `syslog` plugin ([PR187](https://github.com/observIQ/stanza-plugins/pull/187))
   - Update `protocol` parameter valid values field to `rfc5424 (IETF)` and `rfc3164 (BSD)`
   - Update `listen_address` default to 0.0.0.0:514

--- a/plugins/kubernetes_cluster.yaml
+++ b/plugins/kubernetes_cluster.yaml
@@ -1,4 +1,4 @@
-version: 0.0.11
+version: 0.0.12
 title: Kubernetes Node
 description: Log parser for Kubernetes Node
 supported_platforms:
@@ -109,7 +109,14 @@ pipeline:
       - move:
           from: '$record.log'
           to: '$record.message'
-    output: {{ .output }}
+    output: glogs_parser_router
+
+  - id: glogs_parser_router
+    type: router
+    default: {{ .output }}
+    routes:
+      - output: log_restructure
+        expr: '$record.message matches "^\\w\\d{4}"'
 
   # Use journald to gather kubelet logs. Use provided path for journald if available otherwise use default locations.
   - id: kubelet_reader
@@ -144,11 +151,10 @@ pipeline:
   # If message field matches format then, parse it otherwise send down the pipeline.
   - id: kubelet_message_parser_router
     type: router
+    default: {{ .output }}
     routes:
       - output: message_regex_parser
         expr: '$record.message matches "^\\w\\d{4}"'
-      - output: {{ .output }}
-        expr: true
 
   # message field seems to match expected format.
   - id: message_regex_parser

--- a/plugins/kubernetes_cluster.yaml
+++ b/plugins/kubernetes_cluster.yaml
@@ -68,10 +68,10 @@ pipeline:
           to: '$resource["k8s.namespace.name"]'
       - move:
           from: '$record.container_name'
-          to: '$resource["container.name"]'
+          to: '$resource["k8s.container.name"]'
       - move:
           from: '$record.container_id'
-          to: '$resource["container.id"]'
+          to: '$resource["k8s.container.id"]'
 
   # Add kubernetes metadata
   - id: add_kubernetes_metadata
@@ -83,19 +83,19 @@ pipeline:
     type: router
     routes:
       - output: log_restructure
-        expr: '$labels["k8s_pod_label/component"] == "kube-controller-manager"'
+        expr: '$labels["k8s-pod/component"] == "kube-controller-manager"'
         labels:
           log_type: 'k8s.controller'
       - output: log_restructure
-        expr: '$labels["k8s_pod_label/component"]  == "kube-scheduler"'
+        expr: '$labels["k8s-pod/component"]  == "kube-scheduler"'
         labels:
           log_type: 'k8s.scheduler'
       - output: log_restructure
-        expr: '$labels["k8s_pod_label/component"] == "kube-apiserver"'
+        expr: '$labels["k8s-pod/component"] == "kube-apiserver"'
         labels:
           log_type: 'k8s.apiserver'
       - output: log_restructure
-        expr: '$labels["k8s_pod_label/component"] startsWith "kube-proxy"'
+        expr: '$labels["k8s-pod/component"] startsWith "kube-proxy"'
         labels:
           log_type: 'k8s.proxy'
       - output: log_restructure

--- a/plugins/kubernetes_cluster.yaml
+++ b/plugins/kubernetes_cluster.yaml
@@ -160,7 +160,7 @@ pipeline:
   - id: message_regex_parser
     type: regex_parser
     parse_from: message
-    regex: '(?P<severity>\w)(?P<timestamp>\d{4} \d{2}:\d{2}:\d{2}.\d+)\s+(?P<pid>\d+)\s+(?P<source>[^ \]]+)\] (?P<message>.*)'
+    regex: '(?P<severity>\w)(?P<timestamp>\d{4} \d{2}:\d{2}:\d{2}.\d+)\s+(?P<pid>\d+)\s+(?P<src>[^:]*):(?P<src_line>[^\]]*)\] (?P<message>.*)'
     severity:
       parse_from: severity
       mapping:

--- a/plugins/kubernetes_cluster.yaml
+++ b/plugins/kubernetes_cluster.yaml
@@ -115,7 +115,7 @@ pipeline:
     type: router
     default: {{ .output }}
     routes:
-      - output: log_restructure
+      - output: message_regex_parser
         expr: '$record.message matches "^\\w\\d{4}"'
 
   # Use journald to gather kubelet logs. Use provided path for journald if available otherwise use default locations.


### PR DESCRIPTION
Updated labels router to fix the logs types not being added correctly. Also update container name and id label to be consistent with other labels by adding prefix of k8s.
- Add router to route logs to glogs format parser if it matches pattern
- Update label `resource.container.name` to `resource.k8s.container.name`
- Update label `resource.container.id` to `resource.k8s.container.id`
- Update `add_labels_router` to point to correct label name `$labels["k8s-pod/component"]`