### PR TITLE
remove `preserve: false` from timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `kubernetes_events` plugin ([PR186](https://github.com/observIQ/stanza-plugins/pull/186))
   - Add SuccessfulDelete to info severity
+- Update `observiq_agent` plugin ([PR189](https://github.com/observIQ/stanza-plugins/pull/189))
+  - Remove `preserve` field as it has been removed from Stanza in favor of `preserve_to`
 ## [0.0.37] - 2021-01-14
 ### Changed
 - Update `nginx` plugin ([PR184](https://github.com/observIQ/stanza-plugins/pull/184))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add SuccessfulDelete to info severity
 - Update `observiq_agent` plugin ([PR189](https://github.com/observIQ/stanza-plugins/pull/189))
   - Remove `preserve` field as it has been removed from Stanza in favor of `preserve_to`
+- Update `bindplane_agent` plugin ([PR189](https://github.com/observIQ/stanza-plugins/pull/189))
+  - Remove `preserve` field as it has been removed from Stanza in favor of `preserve_to`
 ## [0.0.37] - 2021-01-14
 ### Changed
 - Update `nginx` plugin ([PR184](https://github.com/observIQ/stanza-plugins/pull/184))

--- a/plugins/bindplane_agent.yaml
+++ b/plugins/bindplane_agent.yaml
@@ -1,4 +1,4 @@
-version: 0.0.2
+version: 0.0.3
 title: BindPlane Universal Agent
 description: Agent logs for the BindPlane Universal Agent
 parameters:
@@ -30,7 +30,6 @@ pipeline:
       parse_from: level
     timestamp:
       parse_from: ts
-      preserve: false
       layout_type: gotime
       layout: '2006-01-02T15:04:05.000-0700'
 

--- a/plugins/observiq_agent.yaml
+++ b/plugins/observiq_agent.yaml
@@ -30,7 +30,6 @@ pipeline:
       parse_from: level
     timestamp:
       parse_from: ts
-      preserve: false
       layout_type: gotime
       layout: '2006-01-02T15:04:05.000-0700'
 

--- a/plugins/observiq_agent.yaml
+++ b/plugins/observiq_agent.yaml
@@ -1,4 +1,4 @@
-version: 0.0.2
+version: 0.0.3
 title: observIQ Agent
 description: Agent logs for the observIQ Agent
 parameters:


### PR DESCRIPTION
Timestamp preserve was replaced by preserve_to. https://github.com/observIQ/stanza/blob/master/docs/types/timestamp.md. Observiq_agent is the only plugin that has `preserve` set. 

Because preserve was set to false, removing it does not change behavior.