### PR TITLE
Update tail plugin to reduce complexity in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.39] - Unreleased
 ### Changed
+- Update `tail` plugin ([PR193](https://github.com/observIQ/stanza-plugins/pull/193))
+  - Remove parameters `poll_interval`, `file_name`, and `file_path`
+  - Set to always add file_name label
+  - Add `revelent_if` if `enable_multiline` is true to `multiline_line_start_pattern`
+  - Require `multiline_line_start_pattern` and remove default pattern
+  - Update `log_type` and `multiline_line_start_pattern` description
 ## [0.0.38] - 2021-01-20
 ### Changed
 - Update `jboss` plugin ([PR191](https://github.com/observIQ/stanza-plugins/pull/191))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `tail` plugin ([PR193](https://github.com/observIQ/stanza-plugins/pull/193))
   - Remove parameters `poll_interval`, `file_name`, and `file_path`
   - Set to always add file_name label
-  - Add `revelent_if` if `enable_multiline` is true to `multiline_line_start_pattern`
+  - Add `relevant_if` if `enable_multiline` is true to `multiline_line_start_pattern`
   - Require `multiline_line_start_pattern` and remove default pattern
   - Update `log_type` and `multiline_line_start_pattern` description
 ## [0.0.38] - 2021-01-20

--- a/plugins/tail.yaml
+++ b/plugins/tail.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: Tail
 description: File Input Parser
 parameters:

--- a/plugins/tail.yaml
+++ b/plugins/tail.yaml
@@ -13,11 +13,6 @@ parameters:
     description: An array of file log path glob patterns to be excluded.
     type: strings
     default: []
-  - name: poll_interval
-    label: Poll Interval
-    description: The duration between filesystem polls.
-    type: string
-    default: 200ms
   - name: enable_multiline
     label: Enable Multiline
     description: Enable to parse Multiline Log Files
@@ -25,9 +20,12 @@ parameters:
     default: false
   - name: multiline_line_start_pattern
     label: Multiline Start Pattern
-    description: A Regex pattern to match with start of a line.
+    description: A Regex pattern that matches the start of a multiline log entry in the log file.
     type: string
-    default: "Start of line Regex Pattern"
+    required: true
+    relevant_if:
+      enable_multiline:
+        equals: true
   - name: encoding
     label: Encoding
     description: The encoding of the log file.
@@ -40,29 +38,6 @@ parameters:
       - ascii
       - big5
     default: nop
-  - name: include_file_name
-    label: Include File Name
-    description: Include the log file name.
-    type: bool
-    default: true
-  - name: include_file_path
-    label: Include File Path
-    description: Include the log file path.
-    type: bool
-    default: true
-  - name: start_at
-    label: Start At
-    description: Start reading file from 'beginning' or 'end'
-    type: enum
-    valid_values:
-      - beginning
-      - end
-    default: end
-  - name: log_type
-    label: Log Type
-    description: Adds label log_type to identify tail source.
-    type: string
-    default: tail
   - name: parse_format
     label: Format
     description: The log format to parse.
@@ -71,17 +46,26 @@ parameters:
       - none
       - JSON
     default: none
-
+  - name: log_type
+    label: Log Type
+    description: 'Adds label log_type to identify tail source. In observIQ, the "log_type" will appear as "Type".'
+    type: string
+    default: tail
+  - name: start_at
+    label: Start At
+    description: Start reading file from 'beginning' or 'end'
+    type: enum
+    valid_values:
+      - beginning
+      - end
+    default: end
 # Set Defaults
-# {{$poll_interval := default "200ms" .poll_interval}}
 # {{$enable_multiline := default false .enable_multiline}}
-# {{$multiline_line_start_pattern := default "Start of line Regex Pattern" .multiline_line_start_pattern}}
-# {{$include_file_name := default true .include_file_name}}
-# {{$include_file_path := default true .include_file_path}}
-# {{$log_type := default "tail" .log_type}}
+# {{$multiline_line_start_pattern := default "" .multiline_line_start_pattern}}
 # {{$encoding := default "nop" .encoding}}
-# {{$start_at := default "end" .start_at}}
 # {{$parse_format := default "none" .parse_format}}
+# {{$log_type := default "tail" .log_type}}
+# {{$start_at := default "end" .start_at}}
 
 # Pipeline Template
 pipeline:
@@ -97,7 +81,6 @@ pipeline:
       - '{{ $efp }}'
   # {{ end }}
 # {{ end }}
-    poll_interval: {{ $poll_interval }}
 # {{ if $enable_multiline }}
     multiline:
       line_start_pattern: '{{ $multiline_line_start_pattern }}'
@@ -105,8 +88,7 @@ pipeline:
 # {{ if $encoding }}
     encoding: '{{ $encoding }}'
 # {{ end }}
-    include_file_name: {{ $include_file_name }}
-    include_file_path: {{ $include_file_path }}
+    include_file_name: true
     labels:
       plugin_id: {{ .id }}
       log_type: '{{ $log_type }}'


### PR DESCRIPTION
We removed rarely used parameters. This will reduce the complexity of plugin within UI. In the future we may add the ability to parameters hide under advanced section. Then we may add the removed parameters back.
- Remove parameters `poll_interval`, `file_name`, and `file_path`
- Set to always add file_name label
- Add `revelent_if` if `enable_multiline` is true to `multiline_line_start_pattern`
- Require `multiline_line_start_pattern` and remove default pattern
- Update `log_type` and `multiline_line_start_pattern` description