### PR TITLE
Update apache request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.39] - Unreleased
 ### Added
+- Add `apache_http` plugin ([PR198](https://github.com/observIQ/stanza-plugins/pull/198))
+  - Parse `protocol` and `protocol_version` in default format
+  - Change JSON spec to not nest request fields under request
+  - Update `parse_from` path for access_protocol_parser to $record.protocol
 - Add `journald` plugin ([PR194](https://github.com/observIQ/stanza-plugins/pull/194))
   - Add journald operator as a plugin
 ### Changed

--- a/plugins/apache_http.yaml
+++ b/plugins/apache_http.yaml
@@ -45,7 +45,7 @@ parameters:
       To setup, edit Apache's configuration. Add both log formats to the logging section. On Debian, update all `sites-enabled` configurations to include `CustomLog ${APACHE_LOG_DIR}/access.log observiq`. On CentOS, update Apache's configuration to include `CustomLog "logs/access_log" observiq`.
 
       Access Log Format:
-      Logformat "{\"timestamp\":\"%{%Y-%m-%dT%T}t.%{usec_frac}t%{%z}t\",\"remote_addr\":\"%a\",\"request\":{\"protocol\":\"%H\",\"method\":\"%m\",\"query\":\"%q\",\"path\":\"%U\"},\"status\":\"%>s\",\"http_user_agent\":\"%{User-agent}i\",\"http_referer\":\"%{Referer}i\",\"remote_user\":\"%u\",\"body_bytes_sent\":\"%b\",\"request_time_microseconds\":\"%D\",\"http_x_forwarded_for\":\"%{X-Forwarded-For}i\"}" observiq
+      Logformat "{\"timestamp\":\"%{%Y-%m-%dT%T}t.%{usec_frac}t%{%z}t\",\"remote_addr\":\"%a\",\"protocol\":\"%H\",\"method\":\"%m\",\"query\":\"%q\",\"path\":\"%U\",\"status\":\"%>s\",\"http_user_agent\":\"%{User-agent}i\",\"http_referer\":\"%{Referer}i\",\"remote_user\":\"%u\",\"body_bytes_sent\":\"%b\",\"request_time_microseconds\":\"%D\",\"http_x_forwarded_for\":\"%{X-Forwarded-For}i\"}" observiq
 
       Error Log Format:
       ErrorLogFormat "{\"time\":\"%{cu}t\",\"module\":\"%-m\",\"client\":\"%-a\",\"http_x_forwarded_for\":\"%-{X-Forwarded-For}i\",\"log_level\":\"%-l\",\"pid\":\"%-P\",\"tid\":\"%-T\",\"message\":\"%-M\",\"logid\":{\"request\":\"%-L\",\"connection\":\"%-{c}L\"},\"request_note_name\":\"%-{name}n\"}"

--- a/plugins/apache_http.yaml
+++ b/plugins/apache_http.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 title: Apache HTTP Server
 description: Log parser for Apache HTTP Server
 parameters:
@@ -93,7 +93,7 @@ pipeline:
   # {{ if eq $log_format "default" }}
   - id: access_regex_parser
     type: regex_parser
-    regex: '^(?P<remote_addr>[^ ]*) (?P<remote_host>[^ ]*) (?P<remote_user>[^ ]*) \[(?P<time>[^\]]*)\] "(?P<method>\S+)(?: +(?P<path>[^\"]*?)(?: +\S*)?)?" (?P<status>[^ ]*) (?P<body_bytes_sent>[^ ]*)(?: "(?P<http_referer>[^\"]*)" "(?P<http_user_agent>[^\"]*)"(?:\s+(?P<http_x_forwarded_for>[^ ]+))?)?'
+    regex: '^(?P<remote_addr>[^ ]*) (?P<remote_host>[^ ]*) (?P<remote_user>[^ ]*) \[(?P<time>[^\]]*)\] "(?P<method>\S+) +(?P<path>[^ ]*)( (?P<protocol>[^/]*)/(?P<protocol_version>[^\"]*)|[^\"]*)?" (?P<status>[^ ]*) (?P<body_bytes_sent>[^ ]*)(?: "(?P<http_referer>[^\"]*)" "(?P<http_user_agent>[^\"]*)"(?:\s+(?P<http_x_forwarded_for>[^ ]+))?)?'
     timestamp:
       parse_from: time
       layout: '%d/%b/%Y:%H:%M:%S %z'
@@ -151,8 +151,7 @@ pipeline:
 
   - id: access_protocol_parser
     type: regex_parser
-    parse_from: $record.request.protocol
-    parse_to: $record.request
+    parse_from: $record.protocol
     regex: '(?P<protocol>[^/]*)/(?P<protocol_version>.*)'
     output: {{ .output }}
 


### PR DESCRIPTION
  - Parse `protocol` and `protocol_version` in default format
  - Change JSON spec to not nest request fields under request
  - Update `parse_from` path for access_protocol_parser to $record.protocol