### PR TITLE
Update kubernetes_cluster plugin to parse kublet severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.40] - Unreleased
 ### Changed
+- Update `kubernetes_node` plugin ([PR201](https://github.com/observIQ/stanza-plugins/pull/201))
+  - Add `severity_parser` to parse kubelet severity from $record.PRIORITY when router doesn't match glogs format
 ## [0.0.39] - 2021-01-22
 ### Added
 - Add `journald` plugin ([PR194](https://github.com/observIQ/stanza-plugins/pull/194))
   - Add journald operator as a plugin
 ### Changed
 - Update `oracledb` plugin ([PR199](https://github.com/observIQ/stanza-plugins/pull/199))
-  - Change `status` field to `status_code` in audit and listner logs
+  - Change `status` field to `status_code` in audit and listener logs
 - Update `apache_http` plugin ([PR198](https://github.com/observIQ/stanza-plugins/pull/198))
   - Parse `protocol` and `protocol_version` in default format
   - Change JSON spec to not nest request fields under request

--- a/plugins/kubernetes_cluster.yaml
+++ b/plugins/kubernetes_cluster.yaml
@@ -151,10 +151,23 @@ pipeline:
   # If message field matches format then, parse it otherwise send down the pipeline.
   - id: kubelet_message_parser_router
     type: router
-    default: {{ .output }}
+    default: severity_parser
     routes:
       - output: message_regex_parser
         expr: '$record.message matches "^\\w\\d{4}"'
+
+  - type: severity_parser
+    parse_from: $record.PRIORITY
+    mapping:
+      emergency: 0
+      alert: 1
+      critical: 2
+      error: 3
+      warning: 4
+      notice: 5
+      info: 6
+      debug: 7
+    output: {{ .output }}
 
   # message field seems to match expected format.
   - id: message_regex_parser


### PR DESCRIPTION
- Add `severity_parser` to parse kubelet severity from $record.PRIORITY when router doesn't match glogs format