### PR TITLE
Update tomcat and nginx plugin pod_name parameter default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.40] - Unreleased
 ### Changed
+- Update `tomcat` plugin ([PR203](https://github.com/observIQ/stanza-plugins/pull/203))
+  - Add default for `pod_name` parameter
+- Update `nginx` plugin ([PR203](https://github.com/observIQ/stanza-plugins/pull/203))
+  - Add default for `pod_name` parameter
 ## [0.0.39] - 2021-01-22
 ### Added
 - Add `journald` plugin ([PR194](https://github.com/observIQ/stanza-plugins/pull/194))

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -1,4 +1,4 @@
-version: 0.0.10
+version: 0.0.11
 title: Nginx
 description: Log parser for Nginx
 supported_platforms: 
@@ -19,6 +19,7 @@ parameters:
     label: Pod Name
     description: The pod name (without the unique identifier on the end)
     type: string
+    default: 'nginx-*'
     required: true
     relevant_if:
       source:

--- a/plugins/tomcat.yaml
+++ b/plugins/tomcat.yaml
@@ -1,4 +1,4 @@
-version: 0.0.9
+version: 0.0.10
 title: Apache Tomcat
 description: Log parser for Apache Tomcat
 supported_platforms: 
@@ -20,6 +20,7 @@ parameters:
     description: The pod name (without the unique identifier on the end)
     type: string
     required: true
+    default: 'tomcat-*'
     relevant_if:
       source:
         equals: kubernetes


### PR DESCRIPTION
When setting up Tomcat or NGINX source wtih file as a source, log_agent fails to start. This happens when the `pod_name` parameter field is empty. To fix this issue we add a default of tomcat-* and nginx-*.
  - Add default for `pod_name` parameter in `tomcat`
  - Add default for `pod_name` parameter in `nginx`