### PR TITLE
Update nginx_ingress to fix error produced by router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.40] - Unreleased
 ### Changed
-- Update `kubernetes_node` plugin ([PR201](https://github.com/observIQ/stanza-plugins/pull/201))
+- Update `nginx_ingress` plugin ([PR205](https://github.com/observIQ/stanza-plugins/pull/205))
+  - Update `k8s_input_router` to match from `$record` instead of `$record.message`
+- Update `kubernetes_cluster` plugin ([PR201](https://github.com/observIQ/stanza-plugins/pull/201))
   - Add `severity_parser` to parse kubelet severity from $record.PRIORITY when router doesn't match glogs format
 ## [0.0.39] - 2021-01-22
 ### Added

--- a/plugins/nginx_ingress.yaml
+++ b/plugins/nginx_ingress.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.5
 title: Nginx Ingress
 description: Log parser for Nginx Ingress for Kubernetes
 supported_platforms: 
@@ -90,7 +90,7 @@ pipeline:
           plugin_id: '{{ .id }}'
       # {{ end }}
       # {{ if $enable_error_log }}
-      - expr: '$labels.stream == "stderr" and $record.message matches "\\d{4}\\/\\d{2}\\/\\d{2} \\d{2}:\\d{2}:\\d{2} \\[\\w+\\] \\d+\\.\\d+: "'
+      - expr: '$labels.stream == "stderr" and $record matches "\\d{4}\\/\\d{2}\\/\\d{2} \\d{2}:\\d{2}:\\d{2} \\[\\w+\\] \\d+\\.\\d+: "'
         output: error_regex_parser
         labels:
           log_type: 'nginx.ingress.error'


### PR DESCRIPTION
Plugin would parse messages correctly, but frequently have errors in the logagent.log. This will stop those error messages.
```
{"level":"warn","ts":"2021-01-06T20:14:12.189Z","msg":"Running expression returned an error","operator_id":"$.5dc4a1bd-d85f-48e5-a09e-85b02bc3087c.k8s_input_router","operator_type":"router","error":"invalid operation: int(string) (1:40)\n | $labels.stream == \"stderr\" and $record.message matches \"\\d{4}\\/\\d{2}\\/\\d{2} \\d{2}:\\d{2}:\\d{2} \\[\\w+\\] \\d+\\.\\d+: \"\n | .......................................^"}
```
- Update `k8s_input_router` to match from `$record` instead of `$record.message`