### PR TITLE
Update tomcat nginx and tail plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.40] - Unreleased
 ### Changed
+- Update `tomcat` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
+  - Add default for `pod_name` parameter and remove `required: true`
+  - Update `nginx` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
+  - Add default for `pod_name` parameter  and remove `required: true`
 - Update `kubernetes_node` plugin ([PR201](https://github.com/observIQ/stanza-plugins/pull/201))
   - Add `severity_parser` to parse kubelet severity from $record.PRIORITY when router doesn't match glogs format
 ## [0.0.39] - 2021-01-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.40] - Unreleased
 ### Changed
 - Update `tomcat` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
-  - Add default for `pod_name` parameter and remove `required: true`
+  - Add default for `pod_name` parameter
 - Update `nginx` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
-  - Add default for `pod_name` parameter  and remove `required: true`
+  - Add default for `pod_name` parameter
 - Update `tail` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
-  - Add default for `multiline_line_start_pattern` parameter  and remove `required: true`
+  - Add default for `multiline_line_start_pattern` parameter
 - Update `kubernetes_node` plugin ([PR201](https://github.com/observIQ/stanza-plugins/pull/201))
   - Add `severity_parser` to parse kubelet severity from $record.PRIORITY when router doesn't match glogs format
 ## [0.0.39] - 2021-01-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `tomcat` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
   - Add default for `pod_name` parameter and remove `required: true`
-  - Update `nginx` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
+- Update `nginx` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
   - Add default for `pod_name` parameter  and remove `required: true`
+- Update `tail` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
+  - Add default for `multiline_line_start_pattern` parameter  and remove `required: true`
 - Update `kubernetes_node` plugin ([PR201](https://github.com/observIQ/stanza-plugins/pull/201))
   - Add `severity_parser` to parse kubelet severity from $record.PRIORITY when router doesn't match glogs format
 ## [0.0.39] - 2021-01-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `tomcat` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
   - Add default for `pod_name` parameter
+  - Update description for `log_format`
 - Update `nginx` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
   - Add default for `pod_name` parameter
+  - Update description for `log_format`
 - Update `tail` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
   - Add default for `multiline_line_start_pattern` parameter
 - Update `kubernetes_node` plugin ([PR201](https://github.com/observIQ/stanza-plugins/pull/201))

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -20,6 +20,7 @@ parameters:
     description: The pod name (without the unique identifier on the end)
     type: string
     default: 'nginx-*'
+    required: true
     relevant_if:
       source:
         equals: kubernetes

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -1,6 +1,7 @@
-version: 0.0.10
+version: 0.0.11
 title: Nginx
 description: Log parser for Nginx
+min_stanza_version: 0.13.12
 supported_platforms: 
   - linux
   - windows
@@ -72,14 +73,7 @@ parameters:
     default: end
   - name: log_format
     label: Log Format
-    description: |2
-      Default is unmodifed log_format settings for NGINX
-      log_format combined '$remote_addr - $remote_user [$time_local] '
-                    '"$request" $status $body_bytes_sent '
-                    '"$http_referer" "$http_user_agent"';
-
-      Observiq expects the following format. This format will generate a json log entry. This log_format can be modified to meet your requirements as long as key names do not change and it is valid json.
-      log_format observiq '{"remote_addr":"$remote_addr","remote_user":"$remote_user","time_local":"$time_local","request":"$request","status":"$status","body_bytes_sent":"$body_bytes_sent","http_referer":"$http_referer","http_user_agent":"$http_user_agent","request_length":"$request_length","request_time":"$request_time","upstream_addr":"$upstream_addr","upstream_response_length":"$upstream_response_length","upstream_response_time":"$upstream_response_time","upstream_status":"$upstream_status","proxy_add_x_forwarded_for":"$proxy_add_x_forwarded_for","bytes_sent":"$bytes_sent","time_iso8601":"$time_iso8601","upstream_connect_time":"$upstream_connect_time","upstream_header_time":"$upstream_header_time","http_x_forwarded_for":"$http_x_forwarded_for"}';
+    description: Default is unmodifed log_format settings for NGINX. Observiq is a our recommended spec that we defined to get extra information from the log. See our help documentation for setup requirements.
     type: enum
     valid_values:
       - default
@@ -93,7 +87,7 @@ parameters:
 # {{$enable_error_log := default true .enable_error_log}}
 # {{$error_log_path := default "/var/log/nginx/error.log*" .error_log_path}}
 # {{$start_at := default "end" .start_at}}
-# {{$pod_name := .pod_name}}
+# {{$pod_name := default "nginx-*" .pod_name}}
 # {{$container_name := default "*" .container_name}}
 # {{$log_format := default "default" .log_format}}
 

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -19,7 +19,7 @@ parameters:
     label: Pod Name
     description: The pod name (without the unique identifier on the end)
     type: string
-    required: true
+    default: 'nginx-*'
     relevant_if:
       source:
         equals: kubernetes

--- a/plugins/tail.yaml
+++ b/plugins/tail.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.2
+version: 0.0.3
 title: Tail
 description: File Input Parser
 parameters:
@@ -22,7 +22,7 @@ parameters:
     label: Multiline Start Pattern
     description: A Regex pattern that matches the start of a multiline log entry in the log file.
     type: string
-    required: true
+    default: ''
     relevant_if:
       enable_multiline:
         equals: true

--- a/plugins/tail.yaml
+++ b/plugins/tail.yaml
@@ -2,6 +2,7 @@
 version: 0.0.3
 title: Tail
 description: File Input Parser
+min_stanza_version: 0.13.12
 parameters:
   - name: file_log_path
     label: File Log Path

--- a/plugins/tail.yaml
+++ b/plugins/tail.yaml
@@ -23,6 +23,7 @@ parameters:
     description: A Regex pattern that matches the start of a multiline log entry in the log file.
     type: string
     default: ''
+    required: true
     relevant_if:
       enable_multiline:
         equals: true

--- a/plugins/tomcat.yaml
+++ b/plugins/tomcat.yaml
@@ -1,6 +1,7 @@
-version: 0.0.9
+version: 0.0.10
 title: Apache Tomcat
 description: Log parser for Apache Tomcat
+min_stanza_version: 0.13.12
 supported_platforms: 
   - linux
   - windows
@@ -72,13 +73,7 @@ parameters:
     default: end
   - name: log_format
     label: Log Format
-    description: |2
-      Default is unmodifed log_format settings for Apache HTTP
-      
-      Observiq expects the following format. This format will generate a json log entry. This log_format can be modified to meet your requirements as long as key names do not change and it is valid json.
-      suffix=".json"
-      pattern="{&quot;remote_host&quot;: &quot;%h&quot;,&quot;timestamp&quot;: &quot;%t&quot;,&quot;remote_user&quot;: &quot;%u&quot;,&quot;user_session_id&quot;: &quot;%S&quot;,&quot;method&quot;: &quot;%m&quot;,&quot;path&quot;: &quot;%U&quot;,&quot;status&quot;: &quot;%s&quot;,&quot;bytes_sent&quot;: &quot;%b&quot;,&quot;protocol&quot;: &quot;%H&quot;,&quot;query&quot;: &quot;%q&quot;,&quot;http_x_forwarded_for&quot;: &quot;%{X-Forwarded-For}i&quot;,&quot;user_agent&quot;: &quot;%{User-Agent}i&quot;,&quot;commit_millis&quot;: &quot;%F&quot;,&quot;process_millis&quot;: &quot;%D&quot;,&quot;thread&quot;: &quot;%I&quot;}" />
-
+    description: Default is unmodified log_format settings for Apache HTTP. Observiq is a our recommended spec that we defined to get extra information from the log. See our help documentation for setup requirements.
     type: enum
     valid_values:
       - default
@@ -86,7 +81,7 @@ parameters:
     default: default
 # Set Defaults
 # {{$source := default "file" .source}}
-# {{$pod_name := .pod_name}}
+# {{$pod_name := default "tomcat-*" .pod_name}}
 # {{$container_name := default "*" .container_name}}
 # {{$enable_access_log := default true .enable_access_log}}
 # {{$access_log_path := default "/usr/local/tomcat/logs/localhost_access_log.*.txt" .access_log_path}}

--- a/plugins/tomcat.yaml
+++ b/plugins/tomcat.yaml
@@ -19,7 +19,7 @@ parameters:
     label: Pod Name
     description: The pod name (without the unique identifier on the end)
     type: string
-    required: true
+    default: 'tomcat-*'
     relevant_if:
       source:
         equals: kubernetes

--- a/plugins/tomcat.yaml
+++ b/plugins/tomcat.yaml
@@ -20,6 +20,7 @@ parameters:
     description: The pod name (without the unique identifier on the end)
     type: string
     default: 'tomcat-*'
+    required: true
     relevant_if:
       source:
         equals: kubernetes


### PR DESCRIPTION
When using a parameter with relevant_if and required true. It can cause an issue when starting log agent, if no value is provided for the required parameter when relevant if is false. Stanza has been updated to allow default with required true which will allow this configuration
- Update `tomcat` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
  - Add default for `pod_name` parameter
- Update `nginx` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
  - Add default for `pod_name` parameter
- Update `tail` plugin ([PR206](https://github.com/observIQ/stanza-plugins/pull/206))
  - Add default for `multiline_line_start_pattern` parameter