### PR TITLE
Fix kubelet log timestamps

### DIFF
--- a/plugins/kubernetes_cluster.yaml
+++ b/plugins/kubernetes_cluster.yaml
@@ -48,7 +48,7 @@ pipeline:
 
   # Parse containerd log from $record
   - id: containerd_parser
-    type: regex_parser 
+    type: regex_parser
     regex: '^(?P<time>[^\s]+) (?P<stream>\w+) (?P<partial>\w) (?P<log>.*)'
 
   # Recombine multiline containerd log messages
@@ -203,7 +203,7 @@ pipeline:
     type: router
     default: severity_parser
     routes:
-      - output: message_regex_parser
+      - output: message_regex_parser_kubelet
         expr: '$record.message matches "^\\w\\d{4}"'
 
   # Severity parser for journald
@@ -236,4 +236,31 @@ pipeline:
     timestamp:
       parse_from: timestamp
       layout: '%m%d %H:%M:%S.%s'
+    output: {{ .output }}
+
+  # kubelet logs come from journald with UTC timestamps,
+  # so we ignore the timestamp given in the glog message because
+  # it is known to have the wrong time zone (host's timzone)
+  # unlike the other cluster services that run within containers
+  # using UTC time.
+  - id: message_regex_parser_kubelet
+    type: regex_parser
+    parse_from: message
+    regex: '(?P<severity>\w)(?P<drop_time>\d{4} \d{2}:\d{2}:\d{2}.\d+)\s+(?P<pid>\d+)\s+(?P<src>[^:]*):(?P<src_line>[^\]]*)\] (?P<message>.*)'
+    severity:
+      parse_from: severity
+      mapping:
+        debug: d
+        info: i
+        warning: w
+        error: e
+        critical: c
+    timestamp:
+      parse_from: timestamp
+      layout: '%m%d %H:%M:%S.%s'
+    output: drop_time
+  - id: drop_time
+    type: restructure
+    ops:
+      - remove: '$record.drop_time'
     output: {{ .output }}

--- a/plugins/kubernetes_cluster.yaml
+++ b/plugins/kubernetes_cluster.yaml
@@ -168,6 +168,24 @@ pipeline:
       - output: message_regex_parser
         expr: '$record.message matches "^\\w\\d{4}"'
 
+  # message field seems to match expected format.
+  - id: message_regex_parser
+    type: regex_parser
+    parse_from: message
+    regex: '(?P<severity>\w)(?P<timestamp>\d{4} \d{2}:\d{2}:\d{2}.\d+)\s+(?P<pid>\d+)\s+(?P<src>[^:]*):(?P<src_line>[^\]]*)\] (?P<message>.*)'
+    severity:
+      parse_from: severity
+      mapping:
+        debug: d
+        info: i
+        warning: w
+        error: e
+        critical: c
+    timestamp:
+      parse_from: timestamp
+      layout: '%m%d %H:%M:%S.%s'
+    output: {{ .output }}
+
   # Use journald to gather kubelet logs. Use provided path for journald if available otherwise use default locations.
   - id: kubelet_reader
     type: journald_input
@@ -218,24 +236,6 @@ pipeline:
       notice: 5
       info: 6
       debug: 7
-    output: {{ .output }}
-
-  # message field seems to match expected format.
-  - id: message_regex_parser
-    type: regex_parser
-    parse_from: message
-    regex: '(?P<severity>\w)(?P<timestamp>\d{4} \d{2}:\d{2}:\d{2}.\d+)\s+(?P<pid>\d+)\s+(?P<src>[^:]*):(?P<src_line>[^\]]*)\] (?P<message>.*)'
-    severity:
-      parse_from: severity
-      mapping:
-        debug: d
-        info: i
-        warning: w
-        error: e
-        critical: c
-    timestamp:
-      parse_from: timestamp
-      layout: '%m%d %H:%M:%S.%s'
     output: {{ .output }}
 
   # kubelet logs come from journald with UTC timestamps,


### PR DESCRIPTION
Kubelet logs are retrieved from Journald because it is the only process that runs on the host (unlike the api, controller, manager processes that run as containers). This causes the kubelet's logging package (glog) to use the timestamp the host is set. In our test environments, this is EST. Containers are set to UTC, so the glog messages given by the other core services use the correct timestamps. Additionally, the agent is running within a container so it can assume that timestamps retrieved from /var/log/containers are using the same timezone as itself.

Log entry from a system set to EST time (this log shows up in the destination 5 hours in the past)
```
# journalctl -f | grep kubelet

Feb 02 14:14:03 kube-116-c2-w-1 kubelet[1152]: E0202 14:14:03.962817    1152 pod_workers.go:191] Error syncing pod 330969b8-02fc-4e10-bd26-b49d1862d601 ("recommendationservice-69c56b74d4-2psmb_default(330969b8-02fc-4e10-bd26-b49d1862d601)"), skipping: failed to "StartContainer" for "server" with CrashLoopBackOff: "back-off 5m0s restarting failed container=server pod=recommendationservice-69c56b74d4-2psmb_default(330969b8-02fc-4e10-bd26-b49d1862d601)"
```
Journalctl output has two timestamps
- journalctl time: `Feb 02 14:14:03`
- glog message time: `14:14:03.962817`

The log agent is running in a container, with UTC time. Because the timestamp in the glog message does not include a timezone, the agent assumes UTC (which is five hours in the past). 
```
E0202 14:14:03.962817    1152 pod_workers.go:191] Error sync . . . .
```

The [Journald operator](https://github.com/observIQ/stanza/blob/master/operator/builtin/input/journald/journald.go) solves this by requesting UTC timestamps 
```
// Export logs in UTC time
args = append(args, "--utc")
```

Because the journald timestamp is within miliseconds of the glog timestamp, I think we should just use what journald gives us and ignore the time stamp parsed from the actual message field (glog message). This required two changes
- add a message parser specifically for kubelet, rename timestamp field to `drop_time` to not overwrite the timestamp field already set by journald input
- drop the `drop_time` field with a restructure operation

The alternative approach woudl be to give the user the option of setting a `kubelet_timezone` parameter. I think this adds unnecessary complication when we already have a reliable time source (asking journald to provide UTC).

I have a test environment setup that can quickly replicate this, if anyone wants to hop on a call. 