### PR TITLE
Update kubernetes_cluster plugin to fix timestamp parser error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.42] - Unreleased
 ### Changed
+- Update `kubernetes_cluster` plugin ([PR216](https://github.com/observIQ/stanza-plugins/pull/216)
+  - Fix timestamp parser error when parsing kublet logs.
 ## [0.0.41] - 2021-02-03
 ### Changed
 - Update `syslog` plugin ([PR214](https://github.com/observIQ/stanza-plugins/pull/214))

--- a/plugins/kubernetes_cluster.yaml
+++ b/plugins/kubernetes_cluster.yaml
@@ -1,4 +1,4 @@
-version: 0.0.12
+version: 0.0.13
 title: Kubernetes Node
 description: Log parser for Kubernetes Node
 supported_platforms:
@@ -255,10 +255,8 @@ pipeline:
         warning: w
         error: e
         critical: c
-    timestamp:
-      parse_from: timestamp
-      layout: '%m%d %H:%M:%S.%s'
     output: drop_time
+
   - id: drop_time
     type: restructure
     ops:


### PR DESCRIPTION
This error `"error","ts":"2021-02-03T20:29:01.248Z","msg":"Failed to process entry"` would spam the logagent.log if running kuberentes node plugin and kublet logs were enabled.
- Fix timestamp parser error when parsing kublet logs.