### PR TITLE
Update kubernetes_container plugin to add nested json parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `apache_http`
     - Update `log_format` descriptions
     - Update parameter order
-    - Disable parsing of messages if they match a JSON format from `kubernetes_container`
   - `nginx`
     - Update `source` and `log_format` descriptions
     - Update parameter order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.44] - Unreleased
+### Changed
+- Update plugins ([PR219](https://github.com/observIQ/stanza-plugins/pull/219))
+  - `kubernetes_container`
+    - Add `enable_nested_json_parser` parameter.
+    - Add optional parsing of messages if they match a JSON format
+  - `tomcat`
+    - Update `source` and `log_format` descriptions
+    - Update parameter order
+    - Disable parsing of messages if they match a JSON format from `kubernetes_container`
+  - `apache_http`
+    - Update `log_format` descriptions
+    - Update parameter order
+    - Disable parsing of messages if they match a JSON format from `kubernetes_container`
+  - `nginx`
+    - Update `source` and `log_format` descriptions
+    - Update parameter order
+    - Disable parsing of messages if they match a JSON format from `kubernetes_container`
+  - `nginx_ingress`
+    - Update `log_format` descriptions
+    - Update parameter order
+    - Disable parsing of messages if they match a JSON format from `kubernetes_container`
 ## [0.0.43] - 2021-02-04
+### Changed
 - Update `openshift` plugin ([PR218](https://github.com/observIQ/stanza-plugins/pull/218))
   - Fix regex_parser to handle periods in pod name
   - Fix regex_parser: remove `k8s_` prefix from service name
-### Changed
 ## [0.0.42] - 2021-02-03
 ### Changed
 - Update `kubernetes_cluster` plugin ([PR216](https://github.com/observIQ/stanza-plugins/pull/216)

--- a/plugins/apache_http.yaml
+++ b/plugins/apache_http.yaml
@@ -1,20 +1,15 @@
-version: 0.0.6
+version: 0.0.7
 title: Apache HTTP Server
 description: Log parser for Apache HTTP Server
 parameters:
-  - name: enable_error_log
-    label: Error Logs
-    description: Enable to collect Apache HTTP Server error logs
-    type: bool
-    default: true
-  - name: error_log_path
-    label: Error Log Path
-    description: Path to error log file
-    type: string
-    default: "/var/log/apache2/error.log"
-    relevant_if:
-      enable_error_log:
-        equals: true
+  - name: log_format
+    label: Log Format
+    description: When choosing the 'default' option, the agent will expect and parse logs in a format that matches the default logging configuration. When choosing the 'observIQ' option, the agent will expect and parse logs in an optimized JSON format that adheres to the observIQ specification, requiring an update to the apache2.conf file. See the <a href="https://docs.observiq.com/docs/apache-http-server">Apache HTTP Server source page</a> for more information.
+    type: enum
+    valid_values:
+      - default
+      - observiq
+    default: default
   - name: enable_access_log
     label: Access Logs
     description: Enable to collect Apache HTTP Server access logs
@@ -28,6 +23,19 @@ parameters:
     relevant_if:
       enable_access_log:
         equals: true
+  - name: enable_error_log
+    label: Error Logs
+    description: Enable to collect Apache HTTP Server error logs
+    type: bool
+    default: true
+  - name: error_log_path
+    label: Error Log Path
+    description: Path to error log file
+    type: string
+    default: "/var/log/apache2/error.log"
+    relevant_if:
+      enable_error_log:
+        equals: true
   - name: start_at
     label: Start At
     description: Start reading file from 'beginning' or 'end'
@@ -36,24 +44,6 @@ parameters:
      - beginning
      - end
     default: end
-  - name: log_format
-    label: Log Format
-    description: |2
-      Default is unmodifed log_format settings for Apache HTTPD access.log and error.log
-
-      Observiq Log Format expects the following formats for the access and error logs. This format will generate a json log entry. This log_format can be modified to meet your requirements as long as key names do not change and it is valid json.
-      To setup, edit Apache's configuration. Add both log formats to the logging section. On Debian, update all `sites-enabled` configurations to include `CustomLog ${APACHE_LOG_DIR}/access.log observiq`. On CentOS, update Apache's configuration to include `CustomLog "logs/access_log" observiq`.
-
-      Access Log Format:
-      Logformat "{\"timestamp\":\"%{%Y-%m-%dT%T}t.%{usec_frac}t%{%z}t\",\"remote_addr\":\"%a\",\"protocol\":\"%H\",\"method\":\"%m\",\"query\":\"%q\",\"path\":\"%U\",\"status\":\"%>s\",\"http_user_agent\":\"%{User-agent}i\",\"http_referer\":\"%{Referer}i\",\"remote_user\":\"%u\",\"body_bytes_sent\":\"%b\",\"request_time_microseconds\":\"%D\",\"http_x_forwarded_for\":\"%{X-Forwarded-For}i\"}" observiq
-
-      Error Log Format:
-      ErrorLogFormat "{\"time\":\"%{cu}t\",\"module\":\"%-m\",\"client\":\"%-a\",\"http_x_forwarded_for\":\"%-{X-Forwarded-For}i\",\"log_level\":\"%-l\",\"pid\":\"%-P\",\"tid\":\"%-T\",\"message\":\"%-M\",\"logid\":{\"request\":\"%-L\",\"connection\":\"%-{c}L\"},\"request_note_name\":\"%-{name}n\"}"
-    type: enum
-    valid_values:
-      - default
-      - observiq
-    default: default
 # Set Defaults
 #{{$enable_error_log := default true .enable_error_log}}
 #{{$error_log_path := default "/var/log/apache2/error.log" .error_log_path}}

--- a/plugins/kubernetes_container.yaml
+++ b/plugins/kubernetes_container.yaml
@@ -24,6 +24,10 @@ parameters:
     description: A pattern of files to exclude
     type: strings
     required: false
+  - name: enable_nested_json_parser
+    label: Enable JSON Parsing
+    description: Enable to this to attempt to parse JSON from log message.
+    default: true
   - name: start_at
     label: Start At
     description: "Start reading file from 'beginning' or 'end'"
@@ -37,6 +41,7 @@ parameters:
 # {{ $cluster_name := default "" .cluster_name }}
 # {{ $pod_name := default "*" .pod_name }}
 # {{ $container_name := default "*" .container_name }}
+# {{ $enable_nested_json_parser := default true .enable_nested_json_parser}}
 # {{ $start_at := default "end" .start_at }}
 
 # Pipeline Template
@@ -142,6 +147,7 @@ pipeline:
           from: '$record.container_id'
           to: '$resource["k8s.container.id"]'
 
+# {{ if $enable_nested_json_parser }}
   # Attempt to parse nested JSON in log field if it exists and if JSON is detected
   - id: log_json_router
     type: router
@@ -156,6 +162,7 @@ pipeline:
     type: json_parser
     parse_from: $record.log
     output: add_kubernetes_metadata
+# {{ end }}
 
   # Move message from log field to $record
   - id: move_log_to_record

--- a/plugins/kubernetes_container.yaml
+++ b/plugins/kubernetes_container.yaml
@@ -1,4 +1,4 @@
-version: 0.0.15
+version: 0.0.16
 title: Kubernetes Container
 description: Log parser for Kubernetes
 min_stanza_version: 0.9.8
@@ -142,8 +142,24 @@ pipeline:
           from: '$record.container_id'
           to: '$resource["k8s.container.id"]'
 
+  # Attempt to parse nested JSON in log field if it exists and if JSON is detected
+  - id: log_json_router
+    type: router
+    default: move_log_to_record
+    routes:
+      # It appears to be JSON so send it to be parsed as JSON.
+      - output: nested_json_parser
+        expr: '$record.log != nil and $record.log matches "^{.*}\\s*$"'
+
+  # Attempt to parse nested JSON since the log appears to be JSON
+  - id: nested_json_parser
+    type: json_parser
+    parse_from: $record.log
+    output: add_kubernetes_metadata
+
   # Move message from log field to $record
-  - type: restructure
+  - id: move_log_to_record
+    type: restructure
     ops:
       - move:
           from: log

--- a/plugins/kubernetes_container.yaml
+++ b/plugins/kubernetes_container.yaml
@@ -27,6 +27,7 @@ parameters:
   - name: enable_nested_json_parser
     label: Enable JSON Parsing
     description: Enable to this to attempt to parse JSON from log message.
+    type: bool
     default: true
   - name: start_at
     label: Start At

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -1,4 +1,4 @@
-version: 0.0.11
+version: 0.0.12
 title: Nginx
 description: Log parser for Nginx
 min_stanza_version: 0.13.12
@@ -10,12 +10,20 @@ supported_platforms:
 parameters:
   - name: source
     label: Log source
-    description: Where the logs are coming from
+    description: Use this field to specify where your logs are coming from. When choosing the 'file' option, the agent reads in logs from the log paths specified below.  When choosing the 'Kubernetes' options, the agent reads logs from /var/log/containers based on the Pod and Container specified below.
     type: enum
     valid_values:
       - file
       - kubernetes
     default: file
+  - name: log_format
+    label: Log Format
+    description:  When choosing the 'default' option, the agent will expect and parse logs in a format that matches the default logging configuration. When choosing the 'observIQ' option, the agent will expect and parse logs in an optimized JSON format that adheres to the observIQ specification, requiring an update to the nginx.conf file. See the <a href="https://docs.observiq.com/docs/nginx">NGINX source page</a> for more information.
+    type: enum
+    valid_values:
+      - default
+      - observiq
+    default: default
   - name: pod_name
     label: Pod Name
     description: The pod name (without the unique identifier on the end)
@@ -71,14 +79,6 @@ parameters:
       - beginning
       - end
     default: end
-  - name: log_format
-    label: Log Format
-    description: Default is unmodifed log_format settings for NGINX. Observiq is a our recommended spec that we defined to get extra information from the log. See our help documentation for setup requirements.
-    type: enum
-    valid_values:
-      - default
-      - observiq
-    default: default
 
 # Set Defaults
 # {{$source := default "file" .source}}

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -2,7 +2,7 @@ version: 0.0.11
 title: Nginx
 description: Log parser for Nginx
 min_stanza_version: 0.13.12
-supported_platforms: 
+supported_platforms:
   - linux
   - windows
   - macos
@@ -99,6 +99,7 @@ pipeline:
     pod_name: '{{ $pod_name }}'
     container_name: '{{ $container_name }}'
     start_at: '{{ $start_at }}'
+    enable_nested_json_parser: false
 
   - id: k8s_input_router
     type: router

--- a/plugins/nginx_ingress.yaml
+++ b/plugins/nginx_ingress.yaml
@@ -1,9 +1,21 @@
-version: 0.0.5
+version: 0.0.6
 title: Nginx Ingress
 description: Log parser for Nginx Ingress for Kubernetes
 supported_platforms:
   - kubernetes
 parameters:
+  - name: log_format
+    label: Log Format
+    description: When choosing the 'default' option, the agent will expect and parse logs in a format that matches the default logging configuration. When choosing the 'observIQ' option, the agent will expect and parse logs in an optimized JSON format that adheres to the observIQ specification, requiring an update to the nginx config map. See the <a href="https://docs.observiq.com/docs/nginx-ingress-controller">NGINX Ingress Controller source page</a> for more information.
+    type: enum
+    valid_values:
+      - default
+      - observiq
+    default: default
+  - name: cluster_name
+    label: Cluster Name
+    description: 'Cluster Name to be added to a resource label'
+    type: string
   - name: pod_name
     label: Pod Name
     description: The pod name (without the unique identifier on the end)
@@ -14,10 +26,6 @@ parameters:
     description: The container name of the Nginx container
     type: string
     default: "*"
-  - name: cluster_name
-    label: Cluster Name
-    description: 'Cluster Name to be added to a resource label'
-    type: string
   - name: enable_access_log
     label: Access Logs
     description: Enable to collect Nginx access logs
@@ -36,30 +44,6 @@ parameters:
       - beginning
       - end
     default: end
-  - name: log_format
-    label: Log Format
-    description: |2
-      Default is unmodifed log_format settings for NGINX ingress
-      log_format upstreaminfo
-                    '$remote_addr - $remote_user [$time_local] "$request" '
-                    '$status $body_bytes_sent "$http_referer" "$http_user_agent" '
-                    '$request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr '
-                    '$upstream_response_length $upstream_response_time $upstream_status $req_id';
-
-      Observiq expects the following format. This format will generate a json log entry. This log_format can be modified to meet your requirements as long as key names do not change and it is valid json.
-      log-format-upstream: '{"remote_addr":"$remote_addr","remote_user":"$remote_user","time_local":"$time_local","request":"$request","status":"$status","body_bytes_sent":"$body_bytes_sent","http_referer":"$http_referer","http_user_agent":"$http_user_agent","request_length":"$request_length","request_time":"$request_time","proxy_upstream_name":"$proxy_upstream_name","proxy_alternative_upstream_name":"$proxy_alternative_upstream_name","upstream_addr":"$upstream_addr","upstream_response_length":"$upstream_response_length","upstream_response_time":"$upstream_response_time","upstream_status":"$upstream_status","req_id":"$req_id","proxy_add_x_forwarded_for":"$proxy_add_x_forwarded_for","bytes_sent":"$bytes_sent","time_iso8601":"$time_iso8601","upstream_connect_time":"$upstream_connect_time","upstream_header_time":"$upstream_header_time","namespace":"$namespace","ingress_name":"$ingress_name","service_name":"$service_name","service_port":"$service_port","http_x_forwarded_for":"$http_x_forwarded_for"}'
-    type: enum
-    valid_values:
-      - default
-      - observiq
-    default: default
-  - name: source
-    label: Log source
-    description: Where the logs are coming from
-    type: enum
-    valid_values:
-      - kubernetes
-    default: kubernetes
 
 # Set Defaults
 # {{$enable_access_log := default true .enable_access_log}}

--- a/plugins/nginx_ingress.yaml
+++ b/plugins/nginx_ingress.yaml
@@ -1,11 +1,11 @@
 version: 0.0.5
 title: Nginx Ingress
 description: Log parser for Nginx Ingress for Kubernetes
-supported_platforms: 
+supported_platforms:
   - kubernetes
 parameters:
   - name: pod_name
-    label: Pod Name 
+    label: Pod Name
     description: The pod name (without the unique identifier on the end)
     type: string
     required: true
@@ -45,7 +45,7 @@ parameters:
                     '$status $body_bytes_sent "$http_referer" "$http_user_agent" '
                     '$request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr '
                     '$upstream_response_length $upstream_response_time $upstream_status $req_id';
-      
+
       Observiq expects the following format. This format will generate a json log entry. This log_format can be modified to meet your requirements as long as key names do not change and it is valid json.
       log-format-upstream: '{"remote_addr":"$remote_addr","remote_user":"$remote_user","time_local":"$time_local","request":"$request","status":"$status","body_bytes_sent":"$body_bytes_sent","http_referer":"$http_referer","http_user_agent":"$http_user_agent","request_length":"$request_length","request_time":"$request_time","proxy_upstream_name":"$proxy_upstream_name","proxy_alternative_upstream_name":"$proxy_alternative_upstream_name","upstream_addr":"$upstream_addr","upstream_response_length":"$upstream_response_length","upstream_response_time":"$upstream_response_time","upstream_status":"$upstream_status","req_id":"$req_id","proxy_add_x_forwarded_for":"$proxy_add_x_forwarded_for","bytes_sent":"$bytes_sent","time_iso8601":"$time_iso8601","upstream_connect_time":"$upstream_connect_time","upstream_header_time":"$upstream_header_time","namespace":"$namespace","ingress_name":"$ingress_name","service_name":"$service_name","service_port":"$service_port","http_x_forwarded_for":"$http_x_forwarded_for"}'
     type: enum
@@ -78,6 +78,7 @@ pipeline:
     container_name: '{{ $container_name }}'
     cluster_name: '{{ $cluster_name }}'
     start_at: '{{ $start_at }}'
+    enable_nested_json_parser: false
 
   - id: k8s_input_router
     type: router
@@ -147,7 +148,7 @@ pipeline:
   # {{ end }}
 
   # {{ if $enable_error_log }}
-  # NGINX sends all ingress controller logs to stderr. 
+  # NGINX sends all ingress controller logs to stderr.
   # The ingress controller uses the same container for two services instead of a separate container for each.
   - id: ingress_controller_regex_parser
     type: regex_parser

--- a/plugins/tomcat.yaml
+++ b/plugins/tomcat.yaml
@@ -2,7 +2,7 @@ version: 0.0.10
 title: Apache Tomcat
 description: Log parser for Apache Tomcat
 min_stanza_version: 0.13.12
-supported_platforms: 
+supported_platforms:
   - linux
   - windows
   - macos
@@ -98,6 +98,7 @@ pipeline:
     pod_name: '{{ $pod_name }}'
     container_name: '{{ $container_name }}'
     start_at: '{{ $start_at }}'
+    enable_nested_json_parser: false
 
   - id: k8s_input_router
     type: router

--- a/plugins/tomcat.yaml
+++ b/plugins/tomcat.yaml
@@ -1,4 +1,4 @@
-version: 0.0.10
+version: 0.0.11
 title: Apache Tomcat
 description: Log parser for Apache Tomcat
 min_stanza_version: 0.13.12
@@ -10,12 +10,20 @@ supported_platforms:
 parameters:
   - name: source
     label: Log source
-    description: Where the logs are coming from
+    description: Use this field to specify where your logs are coming from. When choosing the 'file' option, the agent reads in logs from the log paths specified below. When choosing the 'Kubernetes' options, the agent reads logs from /var/log/containers based on the Pod and Container specified below.
     type: enum
     valid_values:
       - file
       - kubernetes
     default: file
+  - name: log_format
+    label: Log Format
+    description: When choosing the 'default' option, the agent will expect and parse logs in a format that matches the default logging configuration. When choosing the 'observIQ' option, the agent will expect and parse logs in an optimized JSON format that adheres to the observIQ specification, requiring an update to the server.xml file. See the <a href="https://docs.observiq.com/docs/apache-tomcat">Apache Tomcat source page</a> for more information.
+    type: enum
+    valid_values:
+      - default
+      - observiq
+    default: default
   - name: pod_name
     label: Pod Name
     description: The pod name (without the unique identifier on the end)
@@ -71,14 +79,6 @@ parameters:
      - beginning
      - end
     default: end
-  - name: log_format
-    label: Log Format
-    description: Default is unmodified log_format settings for Apache HTTP. Observiq is a our recommended spec that we defined to get extra information from the log. See our help documentation for setup requirements.
-    type: enum
-    valid_values:
-      - default
-      - observiq
-    default: default
 # Set Defaults
 # {{$source := default "file" .source}}
 # {{$pod_name := default "tomcat-*" .pod_name}}


### PR DESCRIPTION
In some containers the message field is JSON and we wanted the option to easily parse the nested JSON. This breaks support for plugins that depend on kubernetes_container. We disable this feature in the plugins to avoid this. Also took opportunity to update tooltips and parameter positions.
  - `kubernetes_container`
    - Add `enable_nested_json_parser` parameter.
    - Add optional parsing of messages if they match a JSON format
  - `tomcat`
    - Update `source` and `log_format` descriptions
    - Update parameter order
    - Disable parsing of messages if they match a JSON format from `kubernetes_container`
  - `apache_http`
    - Update `log_format` descriptions
    - Update parameter order
  - `nginx`
    - Update `source` and `log_format` descriptions
    - Update parameter order
    - Disable parsing of messages if they match a JSON format from `kubernetes_container`
  - `nginx_ingress`
    - Update `log_format` descriptions
    - Update parameter order
    - Disable parsing of messages if they match a JSON format from `kubernetes_container`