### PR TITLE
Fix cassandra relevant_if typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.46] - Unreleased
 ### Changed
+- Fix Cassandra parameter's relevant_if typos (equal => equals) [PR223](https://github.com/observIQ/stanza-plugins/pull/222)
+
 ## [0.0.45] - 2021-02-10
 ### Changed
 - Update Syslog plugin ([PR222](https://github.com/observIQ/stanza-plugins/pull/222))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.46] - Unreleased
 ### Changed
-- Fix Cassandra parameter's relevant_if typos (equal => equals) [PR223](https://github.com/observIQ/stanza-plugins/pull/222)
+- Fix Cassandra parameter's relevant_if typos (equal => equals) [PR224](https://github.com/observIQ/stanza-plugins/pull/224)
 
 ## [0.0.45] - 2021-02-10
 ### Changed

--- a/plugins/cassandra.yaml
+++ b/plugins/cassandra.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 title: Apache Cassandra
 description: Log parser for Apache Cassandra
 parameters:

--- a/plugins/cassandra.yaml
+++ b/plugins/cassandra.yaml
@@ -14,7 +14,7 @@ parameters:
     default: "/var/log/cassandra/cassandra.log"
     relevant_if:
       enable_system_logs:
-        equal: true
+        equals: true
   - name: enable_debug_logs
     label: Enable Debug Logs
     description: Enable collection of Cassandra debug logs
@@ -27,7 +27,7 @@ parameters:
     default: "/var/log/cassandra/debug.log"
     relevant_if:
       enable_debug_logs:
-        equal: true
+        equals: true
   - name: enable_gc_logs
     label: Enable Garbage Collection Logs
     description: Enable collection of Cassandra garbage collection logs
@@ -40,7 +40,7 @@ parameters:
     default: "/var/log/cassandra/gc.log"
     relevant_if:
       enable_gc_logs:
-        equal: true
+        equals: true
   - name: start_at
     label: Start At
     description: "Start reading file from 'beginning' or 'end'"


### PR DESCRIPTION
These are defined in both stanza and the front end as `equals`