### PR TITLE
Add sql_command field and fix statement parsing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.47] - Unreleased
 ### Changed
+- Update `postgresql` plugin ([PR227](https://github.com/observIQ/stanza-plugins/pull/227))
+  - Add `sql_command` field
+  - Fix statement parsing error not capturing multiline messages
 ## [0.0.46] - 2021-02-15
 ### Changed
 - Update `syslog` plugin ([PR225](https://github.com/observIQ/stanza-plugins/pull/225))

--- a/plugins/postgresql.yaml
+++ b/plugins/postgresql.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 title: PostgreSQL
 description: 'Log parser for PostgreSQL. This plugin expects the custom settings in postgresql.conf. See our help documentation for setup requirements.'
 parameters:
@@ -61,4 +61,121 @@ pipeline:
     type: regex_parser
     parse_from: $record.message
     regex: '(^STATEMENT:\s*|^statement:\s*)(?P<statement>.*)'
-    output: {{ .output }}
+
+  - id: sql_command_alter
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^ALTER"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "ALTER"
+
+  - id: sql_command_commit
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^COMMIT"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "COMMIT"
+
+  - id: sql_command_copy
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^COPY"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "COPY"
+
+  - id: sql_command_create
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^CREATE"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "CREATE"
+
+  - id: sql_command_delete
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^DELETE"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "DELETE"
+
+  - id: sql_command_drop
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^DROP"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "DROP"
+
+  - id: sql_command_grant
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^GRANT"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "GRANT"
+
+  - id: sql_command_insert
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^INSERT"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "INSERT"
+
+  - id: sql_command_revoke
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^REVOKE"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "REVOKE"
+
+  - id: sql_command_rollback
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^ROLLBACK"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "ROLLBACK"
+
+  - id: sql_command_select
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^SELECT"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "SELECT"
+
+  - id: sql_command_truncate
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^TRUNCATE"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "TRUNCATE"
+
+  - id: sql_command_update
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^UPDATE"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "UPDATE"
+
+  - id: sql_command_vacuum
+    type: restructure
+    if: '$record.statement != nil and $record.statement matches "^VACUUM"'
+    ops:
+      - add:
+          field: "sql_command"
+          value: "VACUUM"
+
+  - id: output_router
+    type: router
+    routes:
+      - output: {{.output}}
+        expr: 'true'

--- a/plugins/postgresql.yaml
+++ b/plugins/postgresql.yaml
@@ -60,7 +60,7 @@ pipeline:
     if: '$record.message matches "^STATEMENT:|^statement:"'
     type: regex_parser
     parse_from: $record.message
-    regex: '(^STATEMENT:\s*|^statement:\s*)(?P<statement>.*)'
+    regex: '(^STATEMENT:\s*|^statement:\s*)(?P<statement>[\w\W]+)'
 
   - id: sql_command_alter
     type: restructure


### PR DESCRIPTION
When capturing statement it would fail to grab whole statement if it included `\n` or `\r`. 
- Add `sql_command` field
- Fix statement parsing error not capturing multiline messages

**statement value before change**
```
"statement": "CREATE TABLE employees (",
```
**statement value after change**
```
CREATE TABLE employees (\n\t   employee_id   NUMERIC       NOT NULL,\n\t   first_name    VARCHAR(1000) NOT NULL,\n\t   last_name     VARCHAR(1000) NOT NULL,\n\t   date_of_birth DATE                   ,\n\t   phone_number  VARCHAR(1000) NOT NULL,\n\t   junk          CHAR(1000)             ,\n\t   CONSTRAINT employees_pk PRIMARY KEY (employee_id)\n\t);\n
```