### PR TITLE
Update hadoop plugin to remove preserve_to from severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.0.48] - Unreleased
 ### Changed
+- Update `hadoop` plugin ([PR230](https://github.com/observIQ/stanza-plugins/pull/230))
+  - Remove `preserve_to` parameter from severity
 ## [0.0.47] - 2021-02-18
 ### Changed
 - Update `mysql` plugin ([PR228](https://github.com/observIQ/stanza-plugins/pull/228))

--- a/plugins/hadoop.yaml
+++ b/plugins/hadoop.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.2
+version: 0.0.3
 title: Apache Hadoop
 description: Log parser for Apache Hadoop
 parameters:
@@ -83,7 +83,6 @@ pipeline:
       layout: '%Y-%m-%d %H:%M:%S'
     severity:
       parse_from: hadoop_severity
-      preserve_to: hadoop_severity
       mapping:
         warning: warn
         critical: fatal
@@ -111,7 +110,6 @@ pipeline:
       layout: '%Y-%m-%d %H:%M:%S'
     severity:
       parse_from: hadoop_severity
-      preserve_to: hadoop_severity
       mapping:
         warning: warn
         critical: fatal
@@ -139,7 +137,6 @@ pipeline:
       layout: '%Y-%m-%d %H:%M:%S'
     severity:
       parse_from: hadoop_severity
-      preserve_to: hadoop_severity
       mapping:
         warning: warn
         critical: fatal


### PR DESCRIPTION
- Remove `preserve_to` parameter from severity