### PR TITLE
Plugin Version Bump To Register Platform Compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `file`
   - `json`
   - `csv`
+- Bumped versions of `zookeeper` and `kafka` plugins so they can be registered with platform information.
 ### Changed
 ## [0.0.50] - 2021-03-18
 ### Changed

--- a/plugins/kafka.yaml
+++ b/plugins/kafka.yaml
@@ -1,4 +1,4 @@
-version: 0.0.2
+version: 0.0.3
 title: Apache Kafka
 description: Log parser for Apache Kafka
 parameters:

--- a/plugins/zookeeper.yaml
+++ b/plugins/zookeeper.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: Apache Zookeeper
 description: Log parser for Apache Zookeeper
 parameters:


### PR DESCRIPTION
These plugins are fairly old and need to be registered by the stanza-source-service in order to be attached to linux, windows, and macos platforms. 