### PR TITLE
Allow max_buffer_size in vmware_vcenter plugin

### DIFF
--- a/plugins/vmware_vcenter.yaml
+++ b/plugins/vmware_vcenter.yaml
@@ -40,6 +40,7 @@ parameters:
 
 # Set Defaults
 # {{$listen_address := default "0.0.0.0:5140" .listen_address}}
+# {{$max_buffer_size := default "1024kib" .max_buffer_size}}
 # {{$enable_tls := default true .enable_tls}}
 # {{$certificate_file := default "" .certificate_file}}
 # {{$private_key_file := default "" .private_key_file}}

--- a/plugins/vmware_vcenter.yaml
+++ b/plugins/vmware_vcenter.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.5
+version: 0.0.6
 title: VMware vCenter
 description: Log parser for VMware vCenter
 parameters:

--- a/plugins/vmware_vcenter.yaml
+++ b/plugins/vmware_vcenter.yaml
@@ -8,6 +8,12 @@ parameters:
     description: A syslog address of the form `<ip>:<port>`
     type: string
     default: "0.0.0.0:5140"
+  - name: max_buffer_size
+    label: Max Buffer Size
+    description: Maximum size of buffer that may be allocated while reading TCP input
+    type: string
+    default: "1024kib"
+    required: false
   - name: enable_tls
     label: Enable TLS
     description: Enable TLS for the TCP listener
@@ -43,6 +49,7 @@ pipeline:
   - id: vcenter_input
     type: tcp_input
     listen_address: {{ $listen_address }}
+    max_buffer_size: {{ $max_buffer_size }}
     labels:
       log_type: vmware_vcenter
       plugin_id: {{ .id }}


### PR DESCRIPTION
Currently seeing issues when collecting logs from vCenter with error message:
{"level":"warn","timestamp":"2021-03-28T22:56:11.428Z","message":"Failed flushing chunk. Waiting before retry","error":"rpc error: code = InvalidArgument desc = Log entry with size 384.5K exceeds maximum size of 256.0K","wait_time":67.136330783}

Setting the parameter `max_buffer_size` in the vmware_vcenter type does not seem to fix the issue and the default value remains 256KiB. This PR adds the optional parameter `max_buffer_size` from `tcp_input`.