### PR TITLE
Add PR238 to changelog. Set min vcenter stanza version to 0.13.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `csv`
 - Bumped versions of `zookeeper` and `kafka` plugins so they can be registered with platform information.
 ### Changed
+- Update VMware vCenter to make use of TCP input's adjustable buffer ([PR238](https://github.com/observIQ/stanza-plugins/pull/238))
+### Changed
 ## [0.0.50] - 2021-03-18
 ### Changed
 - Update `mysql` plugin ([PR234](https://github.com/observIQ/stanza-plugins/pull/234))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped versions of `zookeeper` and `kafka` plugins so they can be registered with platform information.
 ### Changed
 - Update VMware vCenter to make use of TCP input's adjustable buffer ([PR238](https://github.com/observIQ/stanza-plugins/pull/238))
-### Changed
 ## [0.0.50] - 2021-03-18
 ### Changed
 - Update `mysql` plugin ([PR234](https://github.com/observIQ/stanza-plugins/pull/234))

--- a/plugins/vmware_vcenter.yaml
+++ b/plugins/vmware_vcenter.yaml
@@ -2,6 +2,7 @@
 version: 0.0.6
 title: VMware vCenter
 description: Log parser for VMware vCenter
+min_stanza_version: 0.13.16
 parameters:
   - name: listen_address
     label: Listen Address


### PR DESCRIPTION
vCenter with adjustable input buffer is only available in 0.13.16 or later. 