### PR TITLE
Update netmotion to handle bracket in fwver field in structured data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.54] - Unreleased
 ### Changed
+- Update `netmotion` plugin ([PR250](https://github.com/observIQ/stanza-plugins/pull/250))
+  - Add handle bracket in fwver field for structured data.
 - Fixed nested json parsing for Azure Container Logs using Azure Log Analytics ([PR249](https://github.com/observIQ/stanza-plugins/pull/249) 
 - Renamed plugin parameter `name` to `event_hub_name` for Azure plugins Event Hub and Log Analytics ([PR249](https://github.com/observIQ/stanza-plugins/pull/249))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.54] - Unreleased
+## [0.0.55] - Unreleased
 ### Changed
 - Update `netmotion` plugin ([PR250](https://github.com/observIQ/stanza-plugins/pull/250))
   - Add handle bracket in fwver field for structured data.
+
+## [0.0.54] - 2021-05-06
+### Changed
 - Fixed nested json parsing for Azure Container Logs using Azure Log Analytics ([PR249](https://github.com/observIQ/stanza-plugins/pull/249) 
 - Renamed plugin parameter `name` to `event_hub_name` for Azure plugins Event Hub and Log Analytics ([PR249](https://github.com/observIQ/stanza-plugins/pull/249))
 

--- a/plugins/netmotion.yaml
+++ b/plugins/netmotion.yaml
@@ -61,7 +61,7 @@ pipeline:
   # Handle brackets in url2 field
   - id: url2_router
     type: router
-    default: sd_bracket_space_router
+    default: fwver_router
     routes:
       - expr: '$record matches "\\[.*URL2=\".*\\[.*\\\\\\]/\".*\\]"'
         output: url2_parser
@@ -78,6 +78,28 @@ pipeline:
       - add:
           field: $record
           value_expr: '$record.message1 + $record.url1 + $record.url2 + $record.message2'
+    output: fwver_router
+
+  # Handle brackets in fwver field
+  - id: fwver_router
+    type: router
+    default: sd_bracket_space_router
+    routes:
+      - expr: '$record matches "\\[.*fwver=\".*\\[.*\\\\\\]\".*\\]"'
+        output: fwver_parser
+
+  - id: fwver_parser
+    type: regex_parser
+    parse_from: $record
+    regex: '(?P<message1>.*\[.*fwver=")(?P<fwver1>.*)\[(?P<fwver2>.*)\\](?P<message2>".*\].*)'
+    output: fwver_restructurer
+
+  - id: fwver_restructurer
+    type: restructure
+    ops:
+      - add:
+          field: $record
+          value_expr: '$record.message1 + $record.fwver1 + $record.fwver2 + $record.message2'
     output: sd_bracket_space_router
 
   # Handle no space after structured data bracket


### PR DESCRIPTION
Fixed error related to open and closing brackets `[]` in the structured data portion of syslog message.
- Add `fwver_router`, `fwver_parser`, and `fwver_restructurer` to handle bracket in fwver field for structured data.