### PR TITLE
Add supported_platforms for the macos plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.59] - Unreleased
 ### Added
+- Add `supported_platforms` macos for the macos plugin ([PR258](https://github.com/observIQ/stanza-plugins/pull/256))
 
 ## [0.0.58] - 2021-05-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.59] - Unreleased
 ### Added
-- Add `supported_platforms` macos for the macos plugin ([PR258](https://github.com/observIQ/stanza-plugins/pull/256))
+- Add `supported_platforms` macos for the macos plugin ([PR258](https://github.com/observIQ/stanza-plugins/pull/258))
 
 ## [0.0.58] - 2021-05-26
 ### Added

--- a/plugins/macos.yaml
+++ b/plugins/macos.yaml
@@ -1,7 +1,9 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: MacOS
 description: Log parser for MacOS
+supported_platforms: 
+  - macos
 parameters:
   - name: enable_system_log
     label: System Logs


### PR DESCRIPTION
Stanza plugin definitions support a list of supported platforms with a default of macos, linux, and windows. We should specify in this case.