### PR TITLE
Journald: Check if severity parse from field exists before parsing severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.60] - Unreleased
 ### Changed
+- Fixed an issue where journald does not always include the severity parse from field ([PR263](https://github.com/observIQ/stanza-plugins/pull/263))
 
 ## [0.0.59] - 2021-06-08
 ### Added

--- a/plugins/journald.yaml
+++ b/plugins/journald.yaml
@@ -48,6 +48,7 @@ pipeline:
 
   - type: severity_parser
     parse_from: $record.PRIORITY
+    if: '$record.PRIORITY != nil'
     mapping:
       emergency: 0
       alert: 1

--- a/plugins/journald.yaml
+++ b/plugins/journald.yaml
@@ -46,6 +46,8 @@ pipeline:
       plugin_id: {{ .id }}
       log_type: '{{ $log_type }}'
 
+  # Journald does not gaurantee the presence of the PRIORITY
+  # Seveity parsing is skipped if PRIORITY does not exist
   - type: severity_parser
     parse_from: $record.PRIORITY
     if: '$record.PRIORITY != nil'


### PR DESCRIPTION
On Fedora 34 (Systemd 248) I was observing this error:
```json
{
  "level": "error",
  "ts": "2021-06-09T10:09:33.600-0400",
  "msg": "Failed to process entry",
  "operator_id": "$.51fd17b3-e74f-4e5f-80dd-9777f9d2b406.severity_parser",
  "operator_type": "severity_parser",
  "error": {
    "description": "log entry does not have the expected parse_from field",
    "suggestion": "ensure that all entries forwarded to this parser contain the parse_from field",
    "details": {
      "parse_from": "PRIORITY"
    }
  },
  "action": "send",
  "entry": {
    "timestamp": "2021-06-09T10:09:33.337182-04:00",
    "severity": 0,
    "labels": {
      "log_type": "journald",
      "plugin_id": "51fd17b3-e74f-4e5f-80dd-9777f9d2b406"
    },
    "record": {
      "MESSAGE": "BPF prog-id=117 op=UNLOAD",
      "SYSLOG_FACILITY": "4",
      "SYSLOG_IDENTIFIER": "audit",
      "_AUDIT_FIELD_OP": "UNLOAD",
      "_AUDIT_FIELD_PROG_ID": "117",
      "_AUDIT_ID": "1161",
      "_AUDIT_TYPE": "1334",
      "_AUDIT_TYPE_NAME": "BPF",
      "_BOOT_ID": "fb9a177510fa43cebf03dbf6595cbbf7",
      "_HOSTNAME": "fedora",
      "_MACHINE_ID": "3d7a7d5c419d468e81ff7c9a59b2deec",
      "_SOURCE_REALTIME_TIMESTAMP": "1623247773336000",
      "_TRANSPORT": "audit",
      "__CURSOR": "s=4b3029f0a5d44e36ae77146e8954ed02;i=1c00b;b=fb9a177510fa43cebf03dbf6595cbbf7;m=136296ab4f;t=5c455d2e9865e;x=473f2ecee49d2e95",
      "__MONOTONIC_TIMESTAMP": "83258420047"
    }
  }
}
```

Logs were being parsed correctly, however, the log agent log was being polluted. This allows the agent to skip severity parsing if a severity field does not exist in the journald record.

![Screenshot from 2021-06-09 10-29-01](https://user-images.githubusercontent.com/23043836/121374017-89e24f80-c90d-11eb-9814-e3223c123c4e.png)
