### PR TITLE
Update microsoft_iis plugin to use csv parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.0.62] - Unreleased
+### Changed
+- Update `microsoft_iis` plugin ([PR274](https://github.com/observIQ/stanza-plugins/pull/274))
+  - This changes plugin to use `csv_parser`
 
 ## [0.0.61] - 2021-06-10
 ### Changed
-- Update `cisco_meraki` plugin ([PR273](https://github.com/observIQ/stanza-plugins/pull/273))
+- Update `cisco_meraki` plugin ([PR272](https://github.com/observIQ/stanza-plugins/pull/272))
   - Fix parsing errors
 - Update `ubiquiti` plugin, added severity parsing ([267](https://github.com/observIQ/stanza-plugins/pull/267))
 - Update `syslog`, removed special handling ([PR286](https://github.com/observIQ/stanza-plugins/pull/268))

--- a/plugins/microsoft_iis.yaml
+++ b/plugins/microsoft_iis.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.2
+version: 0.0.3
 title: Microsoft IIS
 description: Log parser for Microsoft IIS
 parameters:
@@ -8,6 +8,11 @@ parameters:
     description: The absolute path to the Microsoft IIS logs
     type: string
     default: "C:/inetpub/logs/LogFiles/W3SVC*/**/*.log"
+  - name: fields
+    label: IIS Fields
+    description: 'Fields included in log. The beginning of the log file will have a log entry "#Fields: " copy everything after the ": ". Do not include leading space.'
+    type: string
+    required: true
   - name: start_at
     label: Start At
     description: Start reading file from 'beginning' or 'end'
@@ -19,6 +24,7 @@ parameters:
 
 # Set Defaults
 # {{$file_path := default "C:/inetpub/logs/LogFiles/W3SVC*/**/*.log" .file_path}}
+# {{$fields := .fields}}
 # {{$start_at := default "end" .start_at}}
 
 # Pipeline Template
@@ -27,27 +33,61 @@ pipeline:
     type: file_input
     include:
       - {{ $file_path }}
-    multiline:
-      line_start_pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}|#'
+    # multiline:
+    #   line_start_pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}|#'
     start_at: {{ $start_at }}
     labels:
       log_type: microsoft_iis
       plugin_id: {{ .id }}
-    output: microsoft_iis_parser
+    output: iis_router
 
-  - id: microsoft_iis_parser
+  - id: iis_router
+    type: router
+    routes:
+      - output: quote_handler_parser
+        expr: $record matches '.*".*".*' and not ($record matches "^#")
+      - output: csv_parser
+        expr: 'not ($record matches "^#")'
+      - output: {{ .output }}
+        expr: true
+
+  # Some example log entries have quotes. This will cause an error.
+  # This parses first set of quotes. If more than one set of quotes exist then it will still error.
+  # All examples from logs seen at time of this comment have only contained one set of quotes.
+  - id: quote_handler_parser
     type: regex_parser
-    if: 'not ($record matches "^#")'
-    regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (?P<server_ip>[\d\w\.:]+) (?P<request_method>[A-Z]+) (?P<uri_stem>[^ ]+) (?P<uri_query>[^ ]+) (?P<server_port>\d+) (?P<username>[^ ]+) (?P<client_ip>[\d\w\.:]+) (?P<user_agent>[^ ]+) (?P<referer>[^ ]+) (?P<http_status>\d+) (?P<http_sub_status>\d+) (?P<win32_status>\d+) (?P<time_taken>\d+)'
-    timestamp:
-      parse_from: timestamp
-      layout: '%Y-%m-%d %H:%M:%S'
-    severity:
-      parse_from: http_status
-      preserve_to: http_status
-      mapping:
-        info: 2xx
-        notice: 3xx
-        warning: 4xx
-        error: 5xx
-    output: {{.output}}
+    parse_from: $record
+    regex: '(?P<message1>[^"]*)(?P<first_quote>[\"])(?P<message2>[^"]*)(?P<second_quote>[\"])(?P<message3>.*)'
+    output: quote_handler_restructurer
+
+  # This will remove the first set of parsed quotes.
+  - id: quote_handler_restructurer
+    type: restructure
+    ops:
+      - add:
+          field: $record
+          value_expr: '$record.message1 + $record.message2 + $record.message3'
+    output: csv_parser
+
+  - id: csv_parser
+    type: csv_parser
+    delimiter: " "
+    header: {{ $fields }}
+    output: {{ .output }}
+
+  # - id: microsoft_iis_parser
+  #   type: regex_parser
+  #   if: 'not ($record matches "^#")'
+  #   regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (?P<server_ip>[\d\w\.:]+) (?P<request_method>[A-Z]+) (?P<uri_stem>[^ ]+) (?P<uri_query>[^ ]+) (?P<server_port>\d+) (?P<username>[^ ]+) (?P<client_ip>[\d\w\.:]+) (?P<user_agent>[^ ]+) (?P<referer>[^ ]+) (?P<http_status>\d+) (?P<http_sub_status>\d+) (?P<win32_status>\d+) (?P<time_taken>\d+)'
+  #   timestamp:
+  #     parse_from: timestamp
+  #     layout: '%Y-%m-%d %H:%M:%S'
+  #   severity:
+  #     parse_from: http_status
+  #     preserve_to: http_status
+  #     mapping:
+  #       info: 2xx
+  #       notice: 3xx
+  #       warning: 4xx
+  #       error: 5xx
+  #   output: {{.output}}

--- a/plugins/microsoft_iis.yaml
+++ b/plugins/microsoft_iis.yaml
@@ -2,6 +2,7 @@
 version: 0.0.3
 title: Microsoft IIS
 description: Log parser for Microsoft IIS
+min_stanza_version: 0.14.0
 parameters:
   - name: file_path
     label: Log Path
@@ -76,6 +77,18 @@ pipeline:
     if: '$record.date != nil and $record.time != nil'
     field: $record.timestamp
     value: EXPR($record.date + " " + $record.time)
+
+  # Remove date field
+  - id: remove_date
+    type: remove
+    if: '$record.date != nil'
+    field: $record.date
+
+  # Remove date field
+  - id: remove_time
+    type: remove
+    if: '$record.time != nil'
+    field: $record.time
 
   # Confirm timestamp field exists and parse
   - id: time_parser

--- a/plugins/microsoft_iis.yaml
+++ b/plugins/microsoft_iis.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.3
+version: 1.0.0
 title: Microsoft IIS
 description: Log parser for Microsoft IIS
 min_stanza_version: 0.14.0

--- a/plugins/microsoft_iis.yaml
+++ b/plugins/microsoft_iis.yaml
@@ -62,32 +62,35 @@ pipeline:
 
   # This will remove the first set of parsed quotes.
   - id: quote_handler_restructurer
-    type: restructure
-    ops:
-      - add:
-          field: $record
-          value_expr: '$record.message1 + $record.message2 + $record.message3'
+    type: add
+    field: $record
+    value: 'EXPR($record.message1 + $record.message2 + $record.message3)'
     output: csv_parser
+
 
   - id: csv_parser
     type: csv_parser
     delimiter: " "
     header: {{ $fields }}
-    output: {{ .output }}
 
-  # - id: microsoft_iis_parser
-  #   type: regex_parser
-  #   if: 'not ($record matches "^#")'
-  #   regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (?P<server_ip>[\d\w\.:]+) (?P<request_method>[A-Z]+) (?P<uri_stem>[^ ]+) (?P<uri_query>[^ ]+) (?P<server_port>\d+) (?P<username>[^ ]+) (?P<client_ip>[\d\w\.:]+) (?P<user_agent>[^ ]+) (?P<referer>[^ ]+) (?P<http_status>\d+) (?P<http_sub_status>\d+) (?P<win32_status>\d+) (?P<time_taken>\d+)'
-  #   timestamp:
-  #     parse_from: timestamp
-  #     layout: '%Y-%m-%d %H:%M:%S'
-  #   severity:
-  #     parse_from: http_status
-  #     preserve_to: http_status
-  #     mapping:
-  #       info: 2xx
-  #       notice: 3xx
-  #       warning: 4xx
-  #       error: 5xx
-  #   output: {{.output}}
+  - id: add_timestamp
+    type: add
+    if: '$record.date != nil and $record.time != nil'
+    field: $record.timestamp
+    value: EXPR($record.date + " " + $record.time)
+
+  - id: time_parser
+    type: time_parser
+    if: '$record.timestamp != nil'
+    parse_from: timestamp
+    layout: '%Y-%m-%d %H:%M:%S'
+
+  - type: severity_parser
+    if: '$record["sc-status"] != nil'
+    parse_from: $record.sc-status
+    mapping:
+      info: 2xx
+      notice: 3xx
+      warning: 4xx
+      error: 5xx
+    output: {{.output}}

--- a/plugins/microsoft_iis.yaml
+++ b/plugins/microsoft_iis.yaml
@@ -33,8 +33,6 @@ pipeline:
     type: file_input
     include:
       - {{ $file_path }}
-    # multiline:
-    #   line_start_pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}|#'
     start_at: {{ $start_at }}
     labels:
       log_type: microsoft_iis
@@ -67,24 +65,27 @@ pipeline:
     value: 'EXPR($record.message1 + $record.message2 + $record.message3)'
     output: csv_parser
 
-
   - id: csv_parser
     type: csv_parser
     delimiter: " "
     header: {{ $fields }}
 
+  # Build timestamp from date and time field if they exist
   - id: add_timestamp
     type: add
     if: '$record.date != nil and $record.time != nil'
     field: $record.timestamp
     value: EXPR($record.date + " " + $record.time)
 
+  # Confirm timestamp field exists and parse
   - id: time_parser
     type: time_parser
     if: '$record.timestamp != nil'
     parse_from: timestamp
     layout: '%Y-%m-%d %H:%M:%S'
 
+  # Confirm sc-status field exists then parse severity.
+  # If statement errors when using dot notation because of the - in the field name so use bracket notation instead.
   - type: severity_parser
     if: '$record["sc-status"] != nil'
     parse_from: $record.sc-status


### PR DESCRIPTION
It is possible to configure Microsoft IIS with any number of fields and they may not always be in the same order. This creates errors when regex pattern doesn't match.  A potential solution is found in the beginning of the log file. You will find a list of the fields and their order for each log entry. These fields are separated by a space. Using the `csv_parser` we can ensure we match fields and their order as the fields will have to be provided to use the plugin.

### Example of Fields log line

```
#Fields: date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)
```
Simply copy the fields starting after `:` without leading space, then use it in the `fields` parameter.

### Example config

```
  - type:  microsoft_iis
    file_path: './iis.log'
    fields: 'date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)'
    start_at: beginning
```