### PR TITLE
Cisco meraki message parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.62] - Unreleased
 ### Changed
-- Update `cisco_meraki` plugin ([PR275](https://github.com/observIQ/stanza-plugins/pull/272))
-  - Parse know message field formats
+- Update `cisco_meraki` plugin ([PR275](https://github.com/observIQ/stanza-plugins/pull/275))
+  - Parse known message field formats
 - Update `microsoft_iis` plugin ([PR274](https://github.com/observIQ/stanza-plugins/pull/274))
   - This changes plugin to use `csv_parser`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.62] - Unreleased
 ### Changed
+- Update `cisco_meraki` plugin ([PR275](https://github.com/observIQ/stanza-plugins/pull/272))
+  - Parse know message field formats
 - Update `microsoft_iis` plugin ([PR274](https://github.com/observIQ/stanza-plugins/pull/274))
   - This changes plugin to use `csv_parser`
 

--- a/plugins/cisco_meraki.yaml
+++ b/plugins/cisco_meraki.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.4
+version: 0.0.5
 title: Cisco Meraki
 description: Log parser for Cisco Meraki
 parameters:
@@ -49,20 +49,38 @@ pipeline:
       notice: [5,13,21,29,37,45,53,61,69,77,85,93,101,109,117,125,133,141,149,157,165,173,181,189]
       info: [6,14,22,30,38,46,54,62,70,78,86,94,102,110,118,126,134,142,150,158,166,174,182,190]
       debug: [7,15,23,31,39,47,55,63,71,79,87,95,103,111,119,127,135,143,151,159,167,175,183,191]
-    output: {{ .output }}
+    output: message_router
 
+  # Route messages to different regex's for further parsing. If a regex match is not found then don't parse message.
   - id: message_router
     type: router
     default: {{.output}}
     routes:
-      - expr: '$record matches "^src=[^\\s]*\\s*dst=[^\\s]*\\s*mac=[^\\s]*\\s*protocol=[^\\s]*\\s*sport=[^\\s]*\\s*dport=[^\\s]*"'
-        output: meraki_parser
+      - expr: '$record.message matches "^src=.*\\s*dst=.*\\s*protocol=.*\\s*sport=.*\\s*dport=.*\\s*translated_src_ip=.*\\s*translated_port=.*\\s*"'
+        output: message_1_parser
+      - expr: '$record.message matches "^src=.*\\s*dst=.*\\s*mac=.*\\s*protocol=.*\\s*sport=.*\\s*dport=.*"'
+        output: message_2_parser
+      - expr: '$record.message matches "^src=.*\\s*dst=.*\\s*mac=.*\\s*user=.*\\s*"'
+        output: message_3_parser
 
   - id: message_1_parser
     type: regex_parser
     parse_from: $record.message
+    regex: '^src=(?P<src>[^\s]*)\s*dst=(?P<dst>[^\s]*)\s*protocol=(?P<protocol>[^\s]*)\s*sport=(?P<sport>[^\s]*)\s*dport=(?P<dport>[^\s]*)\s*translated_src_ip=(?P<translated_src_ip>[^\s]*)\s*translated_port=(?P<translated_port>[^\s]*)\s*(?P<message>[\s\S]*)'
+    output: {{.output}}
+
+  - id: message_2_parser
+    type: regex_parser
+    parse_from: $record.message
     regex: '^src=(?P<src>[^\s]*)\s*dst=(?P<dst>[^\s]*)\s*mac=(?P<mac>[^\s]*)\s*protocol=(?P<protocol>[^\s]*)\s*sport=(?P<sport>[^\s]*)\s*dport=(?P<dport>[^\s]*)\s*(?P<message>[\s\S]*)'
     output: {{.output}}
+
+  - id: message_3_parser
+    type: regex_parser
+    parse_from: $record.message
+    regex: '^src=(?P<src>[^\s]*)\s*dst=(?P<dst>[^\s]*)\s*mac=(?P<mac>[^\s]*)\s*user=(?P<user>[^\s]*)\s*(?P<message>[\s\S]*)'
+    output: {{.output}}
+
 
   - id: catch_all_parser
     type: regex_parser

--- a/plugins/cisco_meraki.yaml
+++ b/plugins/cisco_meraki.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.3
+version: 0.0.4
 title: Cisco Meraki
 description: Log parser for Cisco Meraki
 parameters:
@@ -50,6 +50,19 @@ pipeline:
       info: [6,14,22,30,38,46,54,62,70,78,86,94,102,110,118,126,134,142,150,158,166,174,182,190]
       debug: [7,15,23,31,39,47,55,63,71,79,87,95,103,111,119,127,135,143,151,159,167,175,183,191]
     output: {{ .output }}
+
+  - id: message_router
+    type: router
+    default: {{.output}}
+    routes:
+      - expr: '$record matches "^src=[^\\s]*\\s*dst=[^\\s]*\\s*mac=[^\\s]*\\s*protocol=[^\\s]*\\s*sport=[^\\s]*\\s*dport=[^\\s]*"'
+        output: meraki_parser
+
+  - id: message_1_parser
+    type: regex_parser
+    parse_from: $record.message
+    regex: '^src=(?P<src>[^\s]*)\s*dst=(?P<dst>[^\s]*)\s*mac=(?P<mac>[^\s]*)\s*protocol=(?P<protocol>[^\s]*)\s*sport=(?P<sport>[^\s]*)\s*dport=(?P<dport>[^\s]*)\s*(?P<message>[\s\S]*)'
+    output: {{.output}}
 
   - id: catch_all_parser
     type: regex_parser


### PR DESCRIPTION
Based on log examples we can parse message field further. This will add 3 types of log messages to be parsed.