### PR TITLE
Update uwsgi to remove empty message fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.62] - Unreleased
 ### Changed
+- Update `uwsgi` plugin ([PR278](https://github.com/observIQ/stanza-plugins/pull/278))
+  - Remove empty `message` fields
 - Update `cisco_meraki` plugin ([PR275](https://github.com/observIQ/stanza-plugins/pull/275))
   - Parse known message field formats
 - Update `microsoft_iis` plugin ([PR274](https://github.com/observIQ/stanza-plugins/pull/274))

--- a/plugins/uwsgi.yaml
+++ b/plugins/uwsgi.yaml
@@ -1,6 +1,7 @@
 version: 0.0.1
 title: uWSGI Log Parser
 description: Log parser uWSGI formatted logs
+min_stanza_version: 0.14.0
 parameters:
   - name: log_format
     label: Log Format

--- a/plugins/uwsgi.yaml
+++ b/plugins/uwsgi.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 title: uWSGI Log Parser
 description: Log parser uWSGI formatted logs
 min_stanza_version: 0.14.0

--- a/plugins/uwsgi.yaml
+++ b/plugins/uwsgi.yaml
@@ -107,4 +107,9 @@ pipeline:
     type: regex_parser
     parse_from: $record.protocol
     regex: '(?P<protocol>[^/]*)/(?P<protocol_version>.*)'
-    output: {{ .output }}
+
+  # Remove message field if it is empty
+  - type: remove
+    if: '$record.message == ""'
+    field: $record.message
+    output: {{.output}}


### PR DESCRIPTION
This will remove any empty message fields present after record is parsed with `default_regex_parser`.