### PR TITLE
Openshift optional metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `codeigniter` plugin ([PR282](https://github.com/observIQ/stanza-plugins/pull/282))
   - Add multiline message support
   - Parse nested json in message if detected
+- Update `openshift` plugin ([PR283](https://github.com/observIQ/stanza-plugins/pull/283))
+  - Make metadata optional
 ## [0.0.62] - 2021-06-16
 ### Added
 - Add `codeigniter` plugin ([PR276](https://github.com/observIQ/stanza-plugins/pull/276))

--- a/plugins/openshift.yaml
+++ b/plugins/openshift.yaml
@@ -37,12 +37,18 @@ parameters:
     description: Enable collection of Openshift unit logs
     type: bool
     default: true
+  - name: enable_metadata
+    label: Enable Metadata
+    description: Attach metadata to entries https://github.com/observIQ/stanza/blob/master/docs/operators/k8s_metadata_decorator.md
+    type: bool
+    default: true
 
 # Set Defaults
 # {{ $journald_log_path := default "/var/log/journal" .journald_log_path }}
 # {{ $enable_container_logs := default true .enable_container_logs }}
 # {{ $enable_docker_logs := default true .enable_docker_logs }}
 # {{ $enable_openshift_logs := default true .enable_openshift_logs }}
+# {{ $enable_metadata := default true .enable_metadata }}
 # {{ $cluster_name := default "" .cluster_name }}
 # {{ $start_at := default "end" .start_at }}
 
@@ -101,9 +107,10 @@ pipeline:
           from: MESSAGE
           to: '$record'
 
+# {{ if $enable_metadata }}
   # Decorate entries with k8s metadata
   - type: k8s_metadata_decorator
-    output: cluster_name_restructurer
+# {{ end }}
 
   # Add kubernetes cluster name after adding metadata so it doesn't get overwritten
   - id: cluster_name_restructurer

--- a/plugins/openshift.yaml
+++ b/plugins/openshift.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.0.7
+version: 0.0.8
 title: Openshift
 description: Log parser for Openshift
 supported_platforms:

--- a/test/configs/openshift/invalid/invalid_enable_metadata.yaml
+++ b/test/configs/openshift/invalid/invalid_enable_metadata.yaml
@@ -1,0 +1,4 @@
+pipeline:
+- type: openshift
+  enable_metadata: enable
+- type: stdout

--- a/test/configs/openshift/valid/full.yaml
+++ b/test/configs/openshift/valid/full.yaml
@@ -1,0 +1,10 @@
+pipeline:
+- type: openshift
+  journald_log_path: /run/log/journal
+  start_at: end
+  cluster_name: dev
+  enable_container_logs: true
+  enable_docker_logs: false
+  enable_openshift_logs: true
+  enable_metadata: false
+- type: stdout

--- a/test/configs/openshift/valid/minimal.yaml
+++ b/test/configs/openshift/valid/minimal.yaml
@@ -1,0 +1,3 @@
+pipeline:
+- type: openshift
+- type: stdout


### PR DESCRIPTION
We have a request to make metadata optional on Openshift

- added enable_metadata defaulting to true to reflect current behavior
- remove output `output: cluster_name_restructurer`, it is implied and not going to `cluster_name_restructurer` for any particular reason.