### PR TITLE
preserve data.sc-status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.64] - Unreleased
+## [0.0.65] - Unreleased
+
+## [0.0.64] - 2021-06-21
+
+### Fixed
+- Retain sc-status field `microsoft_iis` ([PR287](https://github.com/observIQ/stanza-plugins/pull/287)
 
 ## [0.0.63] - 2021-06-17
 ### Added

--- a/plugins/microsoft_iis.yaml
+++ b/plugins/microsoft_iis.yaml
@@ -110,6 +110,7 @@ pipeline:
   - type: severity_parser
     if: '$record["sc-status"] != nil'
     parse_from: $record.sc-status
+    preserve_to: $record.sc-status
     mapping:
       info: 2xx
       notice: 3xx


### PR DESCRIPTION
sc-status was being dropped after severity parsing, we should retain this field.

<img width="682" alt="Screen Shot 2021-06-21 at 5 25 57 PM" src="https://user-images.githubusercontent.com/23043836/122830016-be62ed80-d2b5-11eb-8681-9a32b2e688e2.png">
