### PR TITLE
Use sane default value for sql server max_reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.66] - Unreleased
 
+### Changed
+- Reduced sqlserver max_reads from 1000 to 100, to combat too many open files error ([PR288](https://github.com/observIQ/stanza-plugins/pull/288))
+
 ## [0.0.65] - 2021-06-23
 
 ### Added

--- a/plugins/sqlserver.yaml
+++ b/plugins/sqlserver.yaml
@@ -12,7 +12,7 @@ parameters:
     label: Max Reads
     description: The maximum number of events read into memory at one time
     type: int
-    default: 1000
+    default: 100
   - name: start_at
     label: Start At
     description: Start reading file from 'beginning' or 'end'

--- a/plugins/sqlserver.yaml
+++ b/plugins/sqlserver.yaml
@@ -24,7 +24,7 @@ parameters:
 
 # Set Defaults
 # {{$poll_interval := default "1s" .poll_interval}}
-# {{$max_reads := default 1000 .max_reads}}
+# {{$max_reads := default 100 .max_reads}}
 # {{$start_at := default "end" .start_at}}
 
 # Pipeline Template


### PR DESCRIPTION
Sometimes sql server plugin will give a "too many open files" error, this is because Windows by default will allow no more than 512 open file handles for a given process. We should set a sane default. 

More context, the Windows event operator defaults to 100 for max_reads, so the plugin should as well. The user is free to increase this value if they want.