### PR TITLE
avoid circular parsing for observiq-agent and bindplane-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.66] - Unreleased
+## [0.0.67] - Unreleased
+
+## [0.0.66] - 2021-06-29
+
+### Changed
+- Openshift: Added observiq-agent and bindplane-agent filters to avoid potential circular parsing ([PR289](https://github.com/observIQ/stanza-plugins/pull/289))
 
 ### Changed
 - Reduced sqlserver max_reads from 1000 to 100, to combat too many open files error ([PR288](https://github.com/observIQ/stanza-plugins/pull/288))

--- a/plugins/openshift.yaml
+++ b/plugins/openshift.yaml
@@ -64,6 +64,12 @@ pipeline:
       # Ignore logs written by Stanza to avoid circular parsing
       - expr: '$record._COMM == "dockerd-current" and $record.CONTAINER_NAME != nil and $record.CONTAINER_NAME matches "stanza"'
         output: drop_output
+      # Ignore logs written by observiq-agent to avoid circular parsing
+      - expr: '$record._COMM == "dockerd-current" and $record.CONTAINER_NAME != nil and $record.CONTAINER_NAME matches "observiq-agent"'
+        output: drop_output
+      # Ignore logs written by bindplane-agent to avoid circular parsing
+      - expr: '$record._COMM == "dockerd-current" and $record.CONTAINER_NAME != nil and $record.CONTAINER_NAME matches "bindplane-agent"'
+        output: drop_output
       # Send all container logs to the container name parser
       - expr: '$record._COMM == "dockerd-current" and $record.CONTAINER_NAME != nil'
         output: '{{ if $enable_container_logs -}} regex_parser {{- else -}} drop_output {{- end }}'


### PR DESCRIPTION
This change allows the openshift plugin to avoid parsing log agent logs from the observiq-agent and bindplane-agent. These agents do not currently write to stdout / stderr but it is possible they will in the future. It is also possible that some users convert from bindplane / observiq agents to stanza for headless configuration. This conversion will likely retain the original pod names.

We already drop output from pods matching `stanza`
```yaml
      # Ignore logs written by Stanza to avoid circular parsing
      - expr: '$record._COMM == "dockerd-current" and $record.CONTAINER_NAME != nil and $record.CONTAINER_NAME matches "stanza"'
        output: drop_output
```