### PR TITLE
Add sampling to netflow and sflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.67] - Unreleased
 
-## [0.0.66] - 2021-06-29
+## [0.0.66] - 2021-06-30
 
 ### Changed
 - Openshift: Added observiq-agent and bindplane-agent filters to avoid potential circular parsing ([PR289](https://github.com/observIQ/stanza-plugins/pull/289))
 - Reduced sqlserver max_reads from 1000 to 100, to combat too many open files error ([PR288](https://github.com/observIQ/stanza-plugins/pull/288))
+- Netflow / Sflow plugins: Added sampling options, for reducing log volume ([PR290](https://github.com/observIQ/stanza-plugins/pull/290))
 
 ## [0.0.65] - 2021-06-23
 

--- a/plugins/netflow.yaml
+++ b/plugins/netflow.yaml
@@ -23,7 +23,7 @@ parameters:
     type: bool
     default: false
   - name: sampling_drop_rate
-    label: Number
+    label: Sampling Drop Rate
     description: The probability an entry is dropped. A value of 1.0 will drop 100% of matching entries, while a value of 0.0 will drop 0%.
     type: enum
     valid_values:

--- a/plugins/netflow.yaml
+++ b/plugins/netflow.yaml
@@ -17,10 +17,36 @@ parameters:
       - v5
       - ipfix
     required: true
+  - name: sampling_enable
+    label: Sampling
+    description: Enable Netflow sampling
+    type: bool
+    default: false
+  - name: sampling_drop_rate
+    label: Number
+    description: The probability an entry is dropped. A value of 1.0 will drop 100% of matching entries, while a value of 0.0 will drop 0%.
+    type: enum
+    valid_values:
+      - 0.0
+      - 0.1
+      - 0.2
+      - 0.3
+      - 0.4
+      - 0.5
+      - 0.6
+      - 0.7
+      - 0.8
+      - 0.9
+      - 1.0
+    relevant_if:
+      enable_internal_access_log:
+        equals: true
 
 # Set Defaults
 # {{$listen_address := default "0.0.0.0" .listen_address}}
 # {{$netflow_version := default "ipfix" .netflow_version}}
+# {{$sampling_enable := default false .sampling_enable}}
+# {{$sampling_drop_rate := default 0.0 .sampling_drop_rate}}
 
 # Pipeline Template
 pipeline:
@@ -35,6 +61,12 @@ pipeline:
     log_type: netflow
     plugin_id: {{ .id }}
     netflow_version: {{ $netflow_version  }}
+
+# {{ if $sampling_enable }}
+- type: filter
+  expr: 'true'
+  drop_ratio: {{ $sampling_drop_rate }}
+# {{ end }}
 
 # Remove goflow specific field
 - type: remove

--- a/plugins/netflow.yaml
+++ b/plugins/netflow.yaml
@@ -39,7 +39,7 @@ parameters:
       - 0.9
       - 1.0
     relevant_if:
-      enable_internal_access_log:
+      sampling_enable:
         equals: true
 
 # Set Defaults

--- a/plugins/sflow.yaml
+++ b/plugins/sflow.yaml
@@ -9,9 +9,35 @@ parameters:
     description: The IP address to bind to
     type: string
     default: "0.0.0.0:6343"
+  - name: sampling_enable
+    label: Sampling
+    description: Enable Netflow sampling
+    type: bool
+    default: false
+  - name: sampling_drop_rate
+    label: Number
+    description: The probability an entry is dropped. A value of 1.0 will drop 100% of matching entries, while a value of 0.0 will drop 0%.
+    type: enum
+    valid_values:
+      - 0.0
+      - 0.1
+      - 0.2
+      - 0.3
+      - 0.4
+      - 0.5
+      - 0.6
+      - 0.7
+      - 0.8
+      - 0.9
+      - 1.0
+    relevant_if:
+      enable_internal_access_log:
+        equals: true
 
 # Set Defaults
 # {{$listen_address := default "0.0.0.0" .listen_address}}
+# {{$sampling_enable := default false .sampling_enable}}
+# {{$sampling_drop_rate := default 0.0 .sampling_drop_rate}}
 
 # Pipeline Template
 pipeline:
@@ -21,6 +47,12 @@ pipeline:
   labels:
     log_type: sflow
     plugin_id: {{ .id }}
+
+# {{ if $sampling_enable }}
+- type: filter
+  expr: 'true'
+  drop_ratio: {{ $sampling_drop_rate }}
+# {{ end }}
 
 # Remove goflow specific field
 - type: remove

--- a/plugins/sflow.yaml
+++ b/plugins/sflow.yaml
@@ -15,7 +15,7 @@ parameters:
     type: bool
     default: false
   - name: sampling_drop_rate
-    label: Number
+    label: Sampling Drop Rate
     description: The probability an entry is dropped. A value of 1.0 will drop 100% of matching entries, while a value of 0.0 will drop 0%.
     type: enum
     valid_values:

--- a/plugins/sflow.yaml
+++ b/plugins/sflow.yaml
@@ -31,7 +31,7 @@ parameters:
       - 0.9
       - 1.0
     relevant_if:
-      enable_internal_access_log:
+      sampling_enable:
         equals: true
 
 # Set Defaults

--- a/test/configs/netflow/invalid/invalid_sampling_drop_rate.yaml
+++ b/test/configs/netflow/invalid/invalid_sampling_drop_rate.yaml
@@ -1,6 +1,7 @@
 pipeline:
 - type: sflow
+  mode: v5
   listen_address: 0.0.0.0:2000
-  workers: 10
-  sampling_enable: false
+  sampling_enable: true
+  sampling_drop_rate: "100"
 - type: stdout

--- a/test/configs/netflow/valid/full_ipfix.yaml
+++ b/test/configs/netflow/valid/full_ipfix.yaml
@@ -3,4 +3,6 @@ pipeline:
   netflow_version: ipfix
   listen_address: 0.0.0.0:2055
   workers: 2
+  sampling_enable: true
+  sampling_drop_rate: "0.5"
 - type: stdout

--- a/test/configs/netflow/valid/full_v5.yaml
+++ b/test/configs/netflow/valid/full_v5.yaml
@@ -3,4 +3,6 @@ pipeline:
   netflow_version: v5
   listen_address: 0.0.0.0:2055
   workers: 15
+  sampling_enable: true
+  sampling_drop_rate: "0.5"
 - type: stdout

--- a/test/configs/sflow/invalid/invalid_sampling_drop_rate.yaml
+++ b/test/configs/sflow/invalid/invalid_sampling_drop_rate.yaml
@@ -2,5 +2,6 @@ pipeline:
 - type: sflow
   listen_address: 0.0.0.0:2000
   workers: 10
-  sampling_enable: false
+  sampling_enable: true
+  sampling_drop_rate: "50%"
 - type: stdout

--- a/test/configs/sflow/valid/full_alt.yaml
+++ b/test/configs/sflow/valid/full_alt.yaml
@@ -2,4 +2,6 @@ pipeline:
 - type: sflow
   listen_address: 0.0.0.0:20001
   workers: 5
+  sampling_enable: true
+  sampling_drop_rate: "0.5"
 - type: stdout


### PR DESCRIPTION
We want to give the user the option of filtering / sampling their netflow / sflow logs. The data can be redundant, therefore it is not necessary to handle every entry.

Default behavior excludes sampling. When enabled, the user has their choice of 0-100% in 10% increments. A sample rate of 0% will filter nothing, and a sample rate of 90% will filter most entries.

In testing, a sample rate of 0.5 produced has as many logs, while a sample rate of 0.0 produced 100% of logs. Testing for short durations is hit and miss but 3 minutes or longer has nice results.

You can test netflow v5 like this
config.yaml (without sample rate)
```yaml
pipeline:
- type: netflow
  netflow_version: v5
  listen_address: 0.0.0.0:2056
- type: stdout
```
```
wc out, 528, 30 seconds
wc out, 4648, 3 minutes
```

config.yaml (with sample rate)
```yaml
pipeline:
- type: netflow
  netflow_version: v5
  listen_address: 0.0.0.0:2056
  sampling_enable: true
  sampling_drop_rate: "0.5"
- type: file_output
  path: out.sampled
```
```
wc out.sampled, 418, 30 seconds
wc out.sampled, 2163, 3 minutes
```

Start Stanza
```bash
./stanza -c ./config.yaml --plugin_dir ./plugins
```

Run a loadgen container. `10.99.1.24` is my ip address, you need to determine your ip address. I believe it will not work with localhost / 127.0.0.1
```bash
docker run -it --rm networkstatic/nflow-generator -t 10.99.1.23 -p 2056
```