### PR TITLE
Add encoding option to Nginx plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.67] - Unreleased
 
+### Changed
+- Nginx: Added optional encoding option ([PR292](https://github.com/observIQ/stanza-plugins/pull/292))
+
 ## [0.0.66] - 2021-06-30
 
 ### Changed

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -87,6 +87,18 @@ parameters:
       - beginning
       - end
     default: end
+  - name: encoding
+    label: Encoding
+    description: Specify the encoding of the file(s) being read. In most cases, you can leave the default option selected.
+    type: enum
+    valid_values:
+      - nop
+      - utf-8
+      - utf-16le
+      - utf-16be
+      - ascii
+      - big5
+    default: nop
 
 # Set Defaults
 # {{$source := default "file" .source}}
@@ -99,6 +111,7 @@ parameters:
 # {{$enable_error_log := default true .enable_error_log}}
 # {{$error_log_path := default "/var/log/nginx/error.log*" .error_log_path}}
 # {{$start_at := default "end" .start_at}}
+# {{$encoding := default "nop" .encoding}}
 
 # Pipeline Template
 pipeline:
@@ -139,6 +152,9 @@ pipeline:
     labels:
       log_type: 'nginx.access'
       plugin_id: '{{ .id }}'
+# {{ if $encoding }}
+    encoding: '{{ $encoding }}'
+# {{ end }}
     output: access_parser
   # {{ end }}
 
@@ -153,6 +169,9 @@ pipeline:
     labels:
       log_type: 'nginx.error'
       plugin_id: '{{ .id }}'
+# {{ if $encoding }}
+    encoding: '{{ $encoding }}'
+# {{ end }}
     output: error_regex_parser
   # {{ end }}
 

--- a/test/configs/nginx/invalid/invalid_encoding.yaml
+++ b/test/configs/nginx/invalid/invalid_encoding.yaml
@@ -8,5 +8,6 @@ pipeline:
   access_log_path: "/var/log/custom/path/nginx/access.log"
   enable_error_log: true
   error_log_path: "/var/log/nginx/errors/error.log*"
-  encoding: utf-8
+  # invalid
+  encoding: us-asciii
   start_at: beginning


### PR DESCRIPTION
Optional encoding parameter for Nginx plugin. Defaulting to `nop` to remain consistent with current behavior of [file input](https://github.com/observIQ/stanza/blob/master/docs/operators/file_input.md).