### PR TITLE
write to record.log is not needed

### DIFF
--- a/plugins/mongodb.yaml
+++ b/plugins/mongodb.yaml
@@ -39,7 +39,6 @@ pipeline:
       log_type: 'mongodb'
       plugin_id: {{ .id }}
     # {{ if $mongodb_json_log_format }}
-    write_to: log
     output: json_parser
     # {{ end }}
 
@@ -68,7 +67,7 @@ pipeline:
 
   - id: json_parser
     type: json_parser
-    parse_from: $record.log
+    parse_from: $record
     timestamp:
       parse_from: $record.t.$date
       #2020-11-03T14:24:07.436-05:00


### PR DESCRIPTION
I am not sure why file_output has `write_to: log`, but it is not needed. The JSON parser has no issue parsing from the top level `$record`. 

With this change, I get no parsing errors in the agent log and the output structure is not changed.



before:
```json
{
  "timestamp": "2021-07-21T13:37:19.987-04:00",
  "severity": 30,
  "severity_text": "I",
  "labels": {
    "file_name": "mongod.log",
    "log_type": "mongodb",
    "plugin_id": "29700b06-ab04-487d-8948-a0a0846ba69e"
  },
  "record": {
    "attr": {
      "connectionCount": 4,
      "connectionId": 14,
      "remote": "10.33.104.99:48496"
    },
    "component": "NETWORK",
    "context": "conn14",
    "id": 22944,
    "message": "Connection ended"
  }
}
```

after:
```json
{
  "timestamp": "2021-07-21T13:36:12.009-04:00",
  "severity": 30,
  "severity_text": "I",
  "labels": {
    "file_name": "mongod.log",
    "log_type": "mongodb",
    "plugin_id": "29700b06-ab04-487d-8948-a0a0846ba69e"
  },
  "record": {
    "attr": {
      "connectionCount": 4,
      "connectionId": 12,
      "remote": "10.33.104.99:48482"
    },
    "component": "NETWORK",
    "context": "conn12",
    "id": 22944,
    "message": "Connection ended"
  }
}
```