### PR TITLE
set default value for file log path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.68] - Unreleased
 
+- Changed: Set default value for json plugin's file_log_path param ([PR297](https://github.com/observIQ/stanza-plugins/pull/297))
+
 ## [0.0.67] - 2021-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.68] - Unreleased
 
 ### Fixed
-- Changed: Set default value for json plugin's file_log_path and pod name param ([PR297](https://github.com/observIQ/stanza-plugins/pull/297))
+- Changed: Removed file_log_path required and added pod name required param ([PR297](https://github.com/observIQ/stanza-plugins/pull/297))
 
 ## [0.0.67] - 2021-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.68] - Unreleased
 
-- Changed: Set default value for json plugin's file_log_path param ([PR297](https://github.com/observIQ/stanza-plugins/pull/297))
+### Fixed
+- Changed: Set default value for json plugin's file_log_path and pod name param ([PR297](https://github.com/observIQ/stanza-plugins/pull/297))
 
 ## [0.0.67] - 2021-08-06
 

--- a/plugins/json.yaml
+++ b/plugins/json.yaml
@@ -30,6 +30,7 @@ parameters:
     description: The pod name (without the unique identifier on the end)
     type: string
     required: true
+    default: ""
     relevant_if:
       source:
         equals: kubernetes

--- a/plugins/json.yaml
+++ b/plugins/json.yaml
@@ -46,6 +46,7 @@ parameters:
     description: Specify a single path or multiple paths to read one or many files. You may also use a wildcard (*) to read multiple files within a directory.
     type: strings
     required: true
+    default: ""
     relevant_if:
       source:
         equals: file
@@ -87,6 +88,7 @@ parameters:
 # {{$cluster_name := default "" .cluster_name}}
 # {{$pod_name := default "" .pod_name}}
 # {{$container_name := default "*" .container_name}}
+# {{$file_log_path := default "" .file_log_path}}
 # {{$encoding := default "utf-8" .encoding}}
 # {{$log_type := default "json" .log_type}}
 # {{$start_at := default "end" .start_at}}

--- a/plugins/json.yaml
+++ b/plugins/json.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.2
+version: 0.0.3
 title: JSON
 description: File Input JSON Parser
 min_stanza_version: 0.13.12

--- a/plugins/json.yaml
+++ b/plugins/json.yaml
@@ -46,8 +46,6 @@ parameters:
     label: File Path
     description: Specify a single path or multiple paths to read one or many files. You may also use a wildcard (*) to read multiple files within a directory.
     type: strings
-    required: true
-    default: ""
     relevant_if:
       source:
         equals: file
@@ -89,7 +87,6 @@ parameters:
 # {{$cluster_name := default "" .cluster_name}}
 # {{$pod_name := default "" .pod_name}}
 # {{$container_name := default "*" .container_name}}
-# {{$file_log_path := default "" .file_log_path}}
 # {{$encoding := default "utf-8" .encoding}}
 # {{$log_type := default "json" .log_type}}
 # {{$start_at := default "end" .start_at}}

--- a/test/configs/json/invalid/missing_file_log_path.yaml
+++ b/test/configs/json/invalid/missing_file_log_path.yaml
@@ -1,3 +1,4 @@
 pipeline:
 - type: json
+  pod_name: ""
 - type: stdout

--- a/test/configs/json/invalid/missing_file_log_path.yaml
+++ b/test/configs/json/invalid/missing_file_log_path.yaml
@@ -1,4 +1,0 @@
-pipeline:
-- type: json
-  pod_name: ""
-- type: stdout


### PR DESCRIPTION
OIQ Cloud agent gives this error
```
{"level":"error","ts":"2021-08-09T14:39:51.174Z","logger":"logagent","msg":"Failed to create new log agent","error":{"description":"missing required parameter for plugin","suggestion":"ensure that the parameter is defined for the plugin","details":{"plugin_type":"json","plugin_parameter":"file_log_path"}}}
```

This is because the parameter is required but does not have a default value, so the platform is omitting it when running on kubernetes.