### PR TITLE
resolve mongodb log type on k8s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.69] - Unreleased
+## [0.0.70] - Unreleased
+
+## [0.0.69] - 2021-08-10
+
+### Changed
+- MongoDB: Resolved an issue where mongodb log_type label is not set on Kubernetes ([PR299](https://github.com/observIQ/stanza-plugins/pull/299))
 
 ## [0.0.68] - 2021-08-09
 

--- a/plugins/mongodb.yaml
+++ b/plugins/mongodb.yaml
@@ -97,7 +97,6 @@ pipeline:
       - '{{ $log_path }}*.gz'
     start_at: '{{ $start_at }}'
     labels:
-      log_type: 'mongodb'
       plugin_id: {{ .id }}
     # {{ if $mongodb_json_log_format }}
     output: json_parser
@@ -150,6 +149,12 @@ pipeline:
           - D3
           - D4
           - D5
+    output: add_log_type
+
+  - id: add_log_type
+    type: add
+    field: $labels.log_type
+    value: mongodb
     output: restructure_log_entry
 
   - id: restructure_log_entry


### PR DESCRIPTION
Instead of setting log type with file input, I added an `add` operator. This will add the log type for file input and kubernetes.