### PR TITLE
add mongodb log type for kubernetes and file input sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.69] - Unreleased
 
 ### Changed
-- MongoDB: Promote WiredTiger message to $record.message ([PR300](https://github.com/observIQ/stanza-plugins/pull/300))
+- MongoDB:
+  - Promote WiredTiger message to $record.message ([PR300](https://github.com/observIQ/stanza-plugins/pull/300))
+  - Set log type when running on Kubernetes ([PR302](https://github.com/observIQ/stanza-plugins/pull/302))
 
 ## [0.0.68] - 2021-08-09
 

--- a/plugins/mongodb.yaml
+++ b/plugins/mongodb.yaml
@@ -1,4 +1,4 @@
-version: 0.0.9
+version: 0.0.10
 title: MongoDB
 description: Log parser for MongoDB
 supported_platforms:
@@ -97,7 +97,6 @@ pipeline:
       - '{{ $log_path }}*.gz'
     start_at: '{{ $start_at }}'
     labels:
-      log_type: 'mongodb'
       plugin_id: {{ .id }}
     # {{ if $mongodb_json_log_format }}
     output: json_parser
@@ -179,4 +178,10 @@ pipeline:
       - move:
           from: '$record.attr.message'
           to: '$record.message'
+    output: add_log_type
+
+  - id: add_log_type
+    type: add
+    field: '$labels.log_type'
+    value: 'mongodb'
     output: {{ .output }}


### PR DESCRIPTION
When using mongodb on kubernetes, the wrong log type label is applied. This is because it was only being set at the file input operator. I have removed this, and added an `add` operator to the end of the pipeline. This way, the log type is added regardless of the log source (kubernetes or file input).

before: `"log_type": "k8s.container",`
```json
{
  "timestamp": "2021-08-11T14:50:57.323Z",
  "severity": 30,
  "severity_text": "I",
  "labels": {
    "k8s-ns/kubernetes.io/metadata.name": "default",
    "k8s-pod/app": "mongo",
    "k8s-pod/pod-template-hash": "55457b675",
    "log_type": "k8s.container",
    "plugin_id": "kubernetes_input",
    "stream": "stdout"
  },
  "resource": {
    "k8s.cluster.name": "stanza_example",
    "k8s.container.id": "c338a244244005d88db8e434b762c939b94102cab7babba57980b4f247b5aae1",
    "k8s.container.name": "wordpress",
    "k8s.deployment.name": "mongodb",
    "k8s.namespace.name": "default",
    "k8s.namespace.uid": "f0d2a872-ea9c-4ca6-a92e-b31571bc76d7",
    "k8s.node.name": "",
    "k8s.pod.name": "mongodb-55457b675-79t5q",
    "k8s.pod.uid": "3ca4719b-7368-4fd8-93db-d625429719ea",
    "k8s.replicaset.name": "mongodb-55457b675"
  },
  "record": {
    "attr": {},
    "component": "STORAGE",
    "context": "Checkpointer",
    "id": 22430,
    "message": "[1628693457:323919][1:0x7f756da2f700], WT_SESSION.checkpoint: [WT_VERB_CHECKPOINT_PROGRESS] saving checkpoint snapshot min: 11, snapshot max: 11 snapshot count: 0, oldest timestamp: (0, 0) , meta checkpoint timestamp: (0, 0) base write gen: 7",
    "message_type": "WiredTiger message"
  }
}
```


after: ` "log_type": "mongodb",`
```json
{
  "timestamp": "2021-08-11T16:10:35.778Z",
  "severity": 30,
  "severity_text": "I",
  "labels": {
    "k8s-ns/kubernetes.io/metadata.name": "default",
    "k8s-pod/app": "mongo",
    "k8s-pod/pod-template-hash": "55457b675",
    "log_type": "mongodb",
    "plugin_id": "kubernetes_input",
    "stream": "stdout"
  },
  "resource": {
    "k8s.cluster.name": "stanza_example",
    "k8s.container.id": "2847c455791fa59a95eb8421dfa4e0205ec540196148a88aed3391b3159654e9",
    "k8s.container.name": "wordpress",
    "k8s.deployment.name": "mongodb",
    "k8s.namespace.name": "default",
    "k8s.namespace.uid": "f0d2a872-ea9c-4ca6-a92e-b31571bc76d7",
    "k8s.node.name": "",
    "k8s.pod.name": "mongodb-55457b675-hkqvj",
    "k8s.pod.uid": "ce262204-49b1-4360-b159-729b6f2334cb",
    "k8s.replicaset.name": "mongodb-55457b675"
  },
  "record": {
    "attr": {},
    "component": "STORAGE",
    "context": "Checkpointer",
    "id": 22430,
    "message": "[1628698235:778708][1:0x7f66684e9700], WT_SESSION.checkpoint: [WT_VERB_CHECKPOINT_PROGRESS] saving checkpoint snapshot min: 5, snapshot max: 5 snapshot count: 0, oldest timestamp: (0, 0) , meta checkpoint timestamp: (0, 0) base write gen: 7",
    "message_type": "WiredTiger message"
  }
}
```