### PR TITLE
add json log type for kubernetes and file input sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MongoDB:
   - Promote WiredTiger message to $record.message ([PR300](https://github.com/observIQ/stanza-plugins/pull/300))
   - Set log type when running on Kubernetes ([PR302](https://github.com/observIQ/stanza-plugins/pull/302))
+- JSON: Set log type when running on kubernetes ([PR303](https://github.com/observIQ/stanza-plugins/pull/303))
 
 ## [0.0.68] - 2021-08-09
 

--- a/plugins/json.yaml
+++ b/plugins/json.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.3
+version: 0.0.4
 title: JSON
 description: File Input JSON Parser
 min_stanza_version: 0.13.12

--- a/plugins/json.yaml
+++ b/plugins/json.yaml
@@ -124,8 +124,12 @@ pipeline:
     include_file_name: true
     labels:
       plugin_id: {{ .id }}
-      log_type: '{{ $log_type }}'
 # {{ end }}
+
+  - id: add_log_type
+    type: add
+    field: '$labels.log_type'
+    value: '{{ $log_type }}'
 
   - type: json_parser
     output: {{ .output }}


### PR DESCRIPTION
Same as: https://github.com/observIQ/stanza-plugins/pull/302

Using the json plugin, I set the log_type parameter to `json_plugin_mongo`, and it is working:
```json
{
  "timestamp": "2021-08-11T16:48:36.119144641Z",
  "severity": 30,
  "severity_text": "stdout",
  "labels": {
    "k8s-ns/kubernetes.io/metadata.name": "default",
    "k8s-pod/app": "mongo",
    "k8s-pod/pod-template-hash": "55457b675",
    "log_type": "json_plugin_mongo",
    "plugin_id": "kubernetes_input",
    "stream": "stdout"
  },
  "resource": {
    "k8s.cluster.name": "stanza_example",
    "k8s.container.id": "2847c455791fa59a95eb8421dfa4e0205ec540196148a88aed3391b3159654e9",
    "k8s.container.name": "wordpress",
    "k8s.deployment.name": "mongodb",
    "k8s.namespace.name": "default",
    "k8s.namespace.uid": "f0d2a872-ea9c-4ca6-a92e-b31571bc76d7",
    "k8s.node.name": "",
    "k8s.pod.name": "mongodb-55457b675-hkqvj",
    "k8s.pod.uid": "ce262204-49b1-4360-b159-729b6f2334cb",
    "k8s.replicaset.name": "mongodb-55457b675"
  },
  "record": {
    "attr": {
      "message": "[1628700516:119015][1:0x7f66684e9700], WT_SESSION.checkpoint: [WT_VERB_CHECKPOINT_PROGRESS] saving checkpoint snapshot min: 43, snapshot max: 43 snapshot count: 0, oldest timestamp: (0, 0) , meta checkpoint timestamp: (0, 0) base write gen: 7"
    },
    "c": "STORAGE",
    "ctx": "Checkpointer",
    "id": 22430,
    "msg": "WiredTiger message",
    "s": "I",
    "t": {
      "$date": "2021-08-11T16:48:36.119+00:00"
    }
  }
}

```