### PR TITLE
journald: add optional poll interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.70] - Unreleased
 
+### Changed
+- Journald: Added optional poll interval parameter ([PR304](https://github.com/observIQ/stanza-plugins/pull/304))
+- OpenShift: Added optional poll interval parameter ([PR304](https://github.com/observIQ/stanza-plugins/pull/304))
+
 ## [0.0.69] - 2021-08-11
 
 ### Changed

--- a/plugins/journald.yaml
+++ b/plugins/journald.yaml
@@ -1,8 +1,8 @@
 # Plugin Info
-version: 1.0.0
+version: 1.0.1
 title: Journald
 description: Journald input parser
-min_stanza_version: 0.14.0
+min_stanza_version: 1.1.6
 supported_platforms:
   - linux
 parameters:
@@ -31,10 +31,15 @@ parameters:
     description: Adds label log_type to identify journald source.
     type: string
     default: journald
+  - name: poll_interval
+    description: How often to poll journald.
+    type: string
+    default: 200ms
 # Set Defaults
 # {{$enable_journald_log_path := default false .enable_journald_log_path}}
 # {{$start_at := default "end" .start_at}}
 # {{$log_type := default "journald" .log_type}}
+# {{$poll_interval := default "200ms" .poll_interval}}
 
 # Pipeline Template
 pipeline:
@@ -46,6 +51,7 @@ pipeline:
     labels:
       plugin_id: {{ .id }}
       log_type: '{{ $log_type }}'
+    poll_interval: '{{ $poll_interval }}'
 
   # Journald does not gaurantee the presence of the PRIORITY
   # Seveity parsing is skipped if PRIORITY does not exist

--- a/plugins/journald.yaml
+++ b/plugins/journald.yaml
@@ -32,6 +32,7 @@ parameters:
     type: string
     default: journald
   - name: poll_interval
+    label: Poll Interval
     description: How often to poll journald.
     type: string
     default: 200ms

--- a/plugins/openshift.yaml
+++ b/plugins/openshift.yaml
@@ -43,6 +43,7 @@ parameters:
     type: bool
     default: true
   - name: poll_interval
+    label: Journald Poll Interval
     description: How often to poll journald.
     type: string
     default: 200ms

--- a/plugins/openshift.yaml
+++ b/plugins/openshift.yaml
@@ -2,6 +2,7 @@
 version: 0.0.9
 title: Openshift
 description: Log parser for Openshift
+min_stanza_version: 1.1.6
 supported_platforms:
   - openshift
 parameters:

--- a/plugins/openshift.yaml
+++ b/plugins/openshift.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.0.8
+version: 0.0.9
 title: Openshift
 description: Log parser for Openshift
 supported_platforms:
@@ -42,6 +42,10 @@ parameters:
     description: Attach metadata to entries https://github.com/observIQ/stanza/blob/master/docs/operators/k8s_metadata_decorator.md
     type: bool
     default: true
+  - name: poll_interval
+    description: How often to poll journald.
+    type: string
+    default: 200ms
 
 # Set Defaults
 # {{ $journald_log_path := default "/var/log/journal" .journald_log_path }}
@@ -51,6 +55,7 @@ parameters:
 # {{ $enable_metadata := default true .enable_metadata }}
 # {{ $cluster_name := default "" .cluster_name }}
 # {{ $start_at := default "end" .start_at }}
+# {{$poll_interval := default "200ms" .poll_interval}}
 
 pipeline:
   - type: journald_input
@@ -58,6 +63,7 @@ pipeline:
     start_at: '{{ $start_at }}'
     labels:
       plugin_id: '{{ .id }}'
+    poll_interval: '{{ $poll_interval }}'
 
   - type: router
     routes:

--- a/test/configs/journald/invalid/invalid_poll_interval.yaml
+++ b/test/configs/journald/invalid/invalid_poll_interval.yaml
@@ -1,5 +1,5 @@
 pipeline:
 - type: journald
   start_at: index
-  poll_interval: 10
+  poll_interval: twenty
 - type: stdout

--- a/test/configs/journald/invalid/invalid_poll_interval.yaml
+++ b/test/configs/journald/invalid/invalid_poll_interval.yaml
@@ -1,0 +1,5 @@
+pipeline:
+- type: journald
+  start_at: index
+  poll_interval: 10
+- type: stdout

--- a/test/configs/journald/valid/full.yaml
+++ b/test/configs/journald/valid/full.yaml
@@ -4,3 +4,4 @@ pipeline:
   journald_log_path: /run/journal
   start_at: end
   log_type: journald_custom
+  poll_interval: 100ms

--- a/test/configs/openshift/invalid/invalid_poll_interval.yaml
+++ b/test/configs/openshift/invalid/invalid_poll_interval.yaml
@@ -1,0 +1,4 @@
+pipeline:
+- type: openshift
+  poll_interval: ten
+- type: stdout

--- a/test/configs/openshift/invalid/invalid_poll_interval.yaml
+++ b/test/configs/openshift/invalid/invalid_poll_interval.yaml
@@ -1,4 +1,4 @@
 pipeline:
 - type: openshift
-  poll_interval: ten
+  poll_interval: 10
 - type: stdout

--- a/test/configs/openshift/valid/full.yaml
+++ b/test/configs/openshift/valid/full.yaml
@@ -7,5 +7,5 @@ pipeline:
   enable_docker_logs: false
   enable_openshift_logs: true
   enable_metadata: false
-  poll_interval: 10
+  poll_interval: "10"
 - type: stdout

--- a/test/configs/openshift/valid/full.yaml
+++ b/test/configs/openshift/valid/full.yaml
@@ -7,4 +7,5 @@ pipeline:
   enable_docker_logs: false
   enable_openshift_logs: true
   enable_metadata: false
+  poll_interval: 10
 - type: stdout


### PR DESCRIPTION
Journald input supports a polling interval as of Stanza 1.1.6: https://github.com/observIQ/stanza/releases/tag/v1.1.6. The default interval for the operator is 200ms. 