### PR TITLE
Add Rails plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -7,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.70] - Unreleased
 
 ### Added
+
 - Added Nodejs plugin ([305](https://github.com/observIQ/stanza-plugins/pull/305))
+- Added Rails plugin ([308](https://github.com/observIQ/stanza-plugins/pull/308))
 
 ## [0.0.69] - 2021-08-11
 

--- a/plugins/rails.yaml
+++ b/plugins/rails.yaml
@@ -1,0 +1,90 @@
+# Plugin Info
+version: 0.0.1
+title: Ruby on Rails
+description: Ruby on Rails log parser. This parser handles json output from lograge.
+min_stanza_version: 0.13.12
+parameters:
+  - name: file_log_path
+    label: File Log Path
+    description: An array of file log path glob patterns.
+    type: strings
+    required: true
+  - name: exclude_file_log_path
+    label: Exclude File Log Path
+    description: An array of file log path glob patterns to be excluded.
+    type: strings
+    default: []
+  - name: parse_format
+    label: Format
+    description: The log format to parse.
+    type: enum
+    valid_values:
+      - JSON
+      - Logger
+    default: JSON
+  - name: start_at
+    label: Start At
+    description: Start reading file from 'beginning' or 'end'
+    type: enum
+    valid_values:
+      - beginning
+      - end
+    default: end
+# Set Defaults
+# {{$parse_format := default "JSON" .parse_format}}
+# {{$start_at := default "end" .start_at}}
+
+# Pipeline Template
+pipeline:
+  - type: file_input
+    start_at: '{{ $start_at }}'
+    include:
+# {{ range $i, $fp := .file_log_path  }}
+      - '{{ $fp }}'
+# {{ end }}
+# {{ if .exclude_file_log_path }}
+    exclude:
+  # {{ range $i, $efp := .exclude_file_log_path  }}
+      - '{{ $efp }}'
+  # {{ end }}
+# {{ end }}
+# {{ if (eq $parse_format "Logger") }}
+    multiline:
+      line_start_pattern: '([\w]+),\s+\[([^\]\s]+)\s+#([^\]]+)\]'
+# {{ end }}
+    include_file_name: true
+    labels:
+      plugin_id: {{ .id }}
+      log_type: 'rails'
+
+# {{ if (eq $parse_format "JSON") }}
+  - type: json_parser
+    if: '$record != nil and $record matches "^{.*}\\s*$"'
+
+  - type: severity_parser
+    if: '$record.status != nil'
+    parse_from: $record.status
+    preset: none
+    preserve_to: status
+    mapping:
+      info: 2xx
+      notice: 3xx
+      warning: 4xx
+      error: 5xx
+# {{ end }}
+
+# {{ if (eq $parse_format "Logger") }}
+  - type: regex_parser
+    regex: '(?P<severity_id>[\w]+),\s+\[(?P<timestamp>[^\]\s]+)\s+#(?P<pid>[^\]]+)\]\s+(?P<severity_text>\w+)\s+--\s+(?P<app>\w+)?:\s+(?P<message>.[\w\W]*)'
+    timestamp:
+      parse_from: timestamp
+      layout_type: gotime
+      layout: '2006-01-02T15:04:05.000000'
+    severity:
+      parse_from: severity_text
+      preserve_to: severity_text
+      mapping:
+        critical: fatal
+        warning: warn
+    output: {{ .output }}
+# {{ end }}

--- a/plugins/rails.yaml
+++ b/plugins/rails.yaml
@@ -14,14 +14,6 @@ parameters:
     description: An array of file log path glob patterns to be excluded.
     type: strings
     default: []
-  - name: parse_format
-    label: Format
-    description: The log format to parse.
-    type: enum
-    valid_values:
-      - JSON
-      - Logger
-    default: JSON
   - name: start_at
     label: Start At
     description: Start reading file from 'beginning' or 'end'
@@ -31,7 +23,6 @@ parameters:
       - end
     default: end
 # Set Defaults
-# {{$parse_format := default "JSON" .parse_format}}
 # {{$start_at := default "end" .start_at}}
 
 # Pipeline Template
@@ -48,18 +39,19 @@ pipeline:
       - '{{ $efp }}'
   # {{ end }}
 # {{ end }}
-# {{ if (eq $parse_format "Logger") }}
-    multiline:
-      line_start_pattern: '([\w]+),\s+\[([^\]\s]+)\s+#([^\]]+)\]'
-# {{ end }}
     include_file_name: true
     labels:
       plugin_id: {{ .id }}
       log_type: 'rails'
 
-# {{ if (eq $parse_format "JSON") }}
+  - id: json_router
+    type: router
+    default: error_regex_parser
+    routes:
+      - output: json_parser
+        expr: '$record matches "^{.*}\\s*$"'
+
   - type: json_parser
-    if: '$record != nil and $record matches "^{.*}\\s*$"'
 
   - id: status_severity_parser
     type: severity_parser
@@ -73,6 +65,11 @@ pipeline:
       warning: 4xx
       error: 5xx
 
+  - id: pid_regex_parser
+    type: regex_parser
+    if: '$record.pid != nil and $record.pid matches "#\\d+"'
+    regex: '#(?P<pid>[\d]+)'
+
   - id: error_severity_parser
     type: severity_parser
     if: '$record.severity != nil'
@@ -82,10 +79,10 @@ pipeline:
       critical: fatal
       warning: warn
     output: {{ .output }}
-# {{ end }}
 
-# {{ if (eq $parse_format "Logger") }}
-  - type: regex_parser
+  - id: error_regex_parser
+    type: regex_parser
+    if: '$record matches "([\\w]+),\\s+\\[([^\\]\\s]+)\\s+#([^\\]]+)\\]\\s+(\\w+)\\s+--\\s+"'
     regex: '(?P<severity_id>[\w]+),\s+\[(?P<timestamp>[^\]\s]+)\s+#(?P<pid>[^\]]+)\]\s+(?P<severity_text>\w+)\s+--\s+(?P<app>\w+)?:\s+(?P<message>.[\w\W]*)'
     timestamp:
       parse_from: timestamp
@@ -98,4 +95,3 @@ pipeline:
         critical: fatal
         warning: warn
     output: {{ .output }}
-# {{ end }}

--- a/plugins/rails.yaml
+++ b/plugins/rails.yaml
@@ -61,7 +61,8 @@ pipeline:
   - type: json_parser
     if: '$record != nil and $record matches "^{.*}\\s*$"'
 
-  - type: severity_parser
+  - id: status_severity_parser
+    type: severity_parser
     if: '$record.status != nil'
     parse_from: $record.status
     preset: none
@@ -71,6 +72,16 @@ pipeline:
       notice: 3xx
       warning: 4xx
       error: 5xx
+
+  - id: error_severity_parser
+    type: severity_parser
+    if: '$record.severity != nil'
+    parse_from: $record.severity
+    preserve_to: $record.severity
+    mapping:
+      critical: fatal
+      warning: warn
+    output: {{ .output }}
 # {{ end }}
 
 # {{ if (eq $parse_format "Logger") }}

--- a/plugins/rails.yaml
+++ b/plugins/rails.yaml
@@ -77,7 +77,7 @@ pipeline:
     type: severity_parser
     if: '$record.severity != nil'
     parse_from: $record.severity
-    preserve_to: $record.severity
+    preserve_to: $record.rails_severity
     mapping:
       critical: fatal
       warning: warn

--- a/schemas/rails.yaml
+++ b/schemas/rails.yaml
@@ -1,0 +1,45 @@
+version: str()
+title: str()
+description: str()
+parameters: list(include('parameter'))
+pipeline: list(include('operator'))
+---
+parameter:
+  name: str()
+  label: str()
+  description: str()
+  type: str()
+  valid_values: list(required=False)
+
+operator:
+  id: str(required=False)
+  type: str()
+  include: list(required=False)
+  start_at: str(required=False)
+  labels: map(str(), required=False)
+  output: str(required=False) 
+  regex: str(required=False)
+  timestamp: map(include('timestamp_list'), str(), map(), required=False)
+  severity: map(include('severity_list'), str(), map(), bool(), required=False)
+
+timestamp_list:
+  parse_from: str()
+  layout: str()
+
+severity_list:
+  parse_from: str()
+  preset: str(required=False)
+  mapping: list(include('mapping_list'), str(), required=False)
+  preserve: bool()
+  if: str(required=False)
+
+mapping_list:
+  info: str(required=False)
+  error: str(required=False)
+  warning: str(required=False)
+  critical: str(required=False)
+  debug: str(required=False)
+  trace: str(required=False)
+  alert: str(required=False)
+  emergency: str(required=False)
+  catastrophe: str(required=False)

--- a/test/configs/rails/invalid/invalid_file_log_path.yaml
+++ b/test/configs/rails/invalid/invalid_file_log_path.yaml
@@ -1,0 +1,6 @@
+pipeline:
+- type: file
+  file_log_path: ""
+  enable_multiline: "multiline"
+  multiline_line_start_pattern: ""
+- type: stdout

--- a/test/configs/rails/invalid/invalid_file_log_path.yaml
+++ b/test/configs/rails/invalid/invalid_file_log_path.yaml
@@ -1,6 +1,4 @@
 pipeline:
-- type: file
+- type: rails
   file_log_path: ""
-  enable_multiline: "multiline"
-  multiline_line_start_pattern: ""
 - type: stdout

--- a/test/configs/rails/invalid/invalid_parse_format.yaml
+++ b/test/configs/rails/invalid/invalid_parse_format.yaml
@@ -1,0 +1,6 @@
+pipeline:
+- type: rails
+  file_log_path:
+  - ""
+  parse_format: invalid
+- type: stdout

--- a/test/configs/rails/invalid/invalid_parse_format.yaml
+++ b/test/configs/rails/invalid/invalid_parse_format.yaml
@@ -1,6 +1,0 @@
-pipeline:
-- type: rails
-  file_log_path:
-  - ""
-  parse_format: invalid
-- type: stdout

--- a/test/configs/rails/valid/minimal.yaml
+++ b/test/configs/rails/valid/minimal.yaml
@@ -1,0 +1,5 @@
+pipeline:
+- type: rails
+  file_log_path: 
+  - ""
+- type: stdout

--- a/test/configs/rails/valid/parse_format.yaml
+++ b/test/configs/rails/valid/parse_format.yaml
@@ -1,0 +1,6 @@
+pipeline:
+- type: rails
+  file_log_path: 
+  - ""
+  parse_format: Logger
+- type: stdout


### PR DESCRIPTION
This adds Rails log parser. This plugin expects lograge to send requests in json format. It also handles error logs are not in json format. The mutliline  message will create each new line as separate log entry. This is unavoidable at this time when you have multiline log entries and single line log entries in same log file.