### PR TITLE
Update IIS to use new w3c plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated microsoft_iis plugin ([PR316](https://github.com/observIQ/stanza-plugins/pull/316))
+- Updated `microsoft_iis` and `w3c` plugin ([PR316](https://github.com/observIQ/stanza-plugins/pull/316))
   - Update plugin to use new w3c plugin.
+
 
 ## [0.0.72] - 2021-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.72] - Unreleased
+
+### Changed
+
+- Updated microsoft_iis plugin ([PR316](https://github.com/observIQ/stanza-plugins/pull/316))
+  - Update plugin to use new w3c plugin.
 
 ## [0.0.72] - 2021-08-25
 

--- a/plugins/microsoft_iis.yaml
+++ b/plugins/microsoft_iis.yaml
@@ -1,25 +1,45 @@
 # Plugin Info
-version: 1.0.1
+version: 1.1.0
 title: Microsoft IIS
 description: Log parser for Microsoft IIS
-min_stanza_version: 0.14.0
+min_stanza_version: 1.2.1
 parameters:
-  - name: file_path
+  - name: file_log_path
     label: Log Path
-    description: The absolute path to the Microsoft IIS logs
-    type: string
-    default: "C:/inetpub/logs/LogFiles/W3SVC*/**/*.log"
-  - name: fields
-    label: IIS Fields
-    description: 'Fields included in log. The beginning of the log file will have a log entry "#Fields: " copy everything after the ": ". Do not include leading space.'
-    type: string
-    required: true
+    description: Specify a single path or multiple paths to read one or many files. You may also use a wildcard (*) to read multiple files within a directory.
+    type: strings
+    default: ["C:/inetpub/logs/LogFiles/W3SVC*/**/*.log"]
+  - name: exclude_file_log_path
+    label: Exclude File Path
+    description: Specify a single path or multiple paths to exclude one or many files from being read. You may also use a wildcard (*) to exclude multiple files from being read within a directory.
+    type: strings
+    default: []
   - name: location
     label: Geographic Location
     description: The geographic location (timezone) to use when parsing the timestamp
     type: enum
     valid_values: ["Africa/Abidjan","Africa/Accra","Africa/Addis_Ababa","Africa/Algiers","Africa/Asmara","Africa/Bamako","Africa/Bangui","Africa/Banjul","Africa/Bissau","Africa/Blantyre","Africa/Brazzaville","Africa/Bujumbura","Africa/Cairo","Africa/Casablanca","Africa/Ceuta","Africa/Conakry","Africa/Dakar","Africa/Dar_es_Salaam","Africa/Djibouti","Africa/Douala","Africa/El_Aaiun","Africa/Freetown","Africa/Gaborone","Africa/Harare","Africa/Johannesburg","Africa/Juba","Africa/Kampala","Africa/Khartoum","Africa/Kigali","Africa/Kinshasa","Africa/Lagos","Africa/Libreville","Africa/Lome","Africa/Luanda","Africa/Lubumbashi","Africa/Lusaka","Africa/Malabo","Africa/Maputo","Africa/Maseru","Africa/Mbabane","Africa/Mogadishu","Africa/Monrovia","Africa/Nairobi","Africa/Ndjamena","Africa/Niamey","Africa/Nouakchott","Africa/Ouagadougou","Africa/Porto-Novo","Africa/Sao_Tome","Africa/Tripoli","Africa/Tunis","Africa/Windhoek","America/Adak","America/Anchorage","America/Anguilla","America/Antigua","America/Araguaina","America/Argentina/Buenos_Aires","America/Argentina/Catamarca","America/Argentina/Cordoba","America/Argentina/Jujuy","America/Argentina/La_Rioja","America/Argentina/Mendoza","America/Argentina/Rio_Gallegos","America/Argentina/Salta","America/Argentina/San_Juan","America/Argentina/San_Luis","America/Argentina/Tucuman","America/Argentina/Ushuaia","America/Aruba","America/Asuncion","America/Atikokan","America/Bahia","America/Bahia_Banderas","America/Barbados","America/Belem","America/Belize","America/Blanc-Sablon","America/Boa_Vista","America/Bogota","America/Boise","America/Cambridge_Bay","America/Campo_Grande","America/Cancun","America/Caracas","America/Cayenne","America/Cayman","America/Chicago","America/Chihuahua","America/Costa_Rica","America/Creston","America/Cuiaba","America/Curacao","America/Danmarkshavn","America/Dawson","America/Dawson_Creek","America/Denver","America/Detroit","America/Dominica","America/Edmonton","America/Eirunepe","America/El_Salvador","America/Fort_Nelson","America/Fortaleza","America/Glace_Bay","America/Goose_Bay","America/Grand_Turk","America/Grenada","America/Guadeloupe","America/Guatemala","America/Guayaquil","America/Guyana","America/Halifax","America/Havana","America/Hermosillo","America/Indiana/Indianapolis","America/Indiana/Knox","America/Indiana/Marengo","America/Indiana/Petersburg","America/Indiana/Tell_City","America/Indiana/Vevay","America/Indiana/Vincennes","America/Indiana/Winamac","America/Inuvik","America/Iqaluit","America/Jamaica","America/Juneau","America/Kentucky/Louisville","America/Kentucky/Monticello","America/Kralendijk","America/La_Paz","America/Lima","America/Los_Angeles","America/Lower_Princes","America/Maceio","America/Managua","America/Manaus","America/Marigot","America/Martinique","America/Matamoros","America/Mazatlan","America/Menominee","America/Merida","America/Metlakatla","America/Mexico_City","America/Miquelon","America/Moncton","America/Monterrey","America/Montevideo","America/Montserrat","America/Nassau","America/New_York","America/Nipigon","America/Nome","America/Noronha","America/North_Dakota/Beulah","America/North_Dakota/Center","America/North_Dakota/New_Salem","America/Nuuk","America/Ojinaga","America/Panama","America/Pangnirtung","America/Paramaribo","America/Phoenix","America/Port-au-Prince","America/Port_of_Spain","America/Porto_Velho","America/Puerto_Rico","America/Punta_Arenas","America/Rainy_River","America/Rankin_Inlet","America/Recife","America/Regina","America/Resolute","America/Rio_Branco","America/Santarem","America/Santiago","America/Santo_Domingo","America/Sao_Paulo","America/Scoresbysund","America/Sitka","America/St_Barthelemy","America/St_Johns","America/St_Kitts","America/St_Lucia","America/St_Thomas","America/St_Vincent","America/Swift_Current","America/Tegucigalpa","America/Thule","America/Thunder_Bay","America/Tijuana","America/Toronto","America/Tortola","America/Vancouver","America/Whitehorse","America/Winnipeg","America/Yakutat","America/Yellowknife","Antarctica/Casey","Antarctica/Davis","Antarctica/DumontDUrville","Antarctica/Macquarie","Antarctica/Mawson","Antarctica/McMurdo","Antarctica/Palmer","Antarctica/Rothera","Antarctica/Syowa","Antarctica/Troll","Antarctica/Vostok","Arctic/Longyearbyen","Asia/Aden","Asia/Almaty","Asia/Amman","Asia/Anadyr","Asia/Aqtau","Asia/Aqtobe","Asia/Ashgabat","Asia/Atyrau","Asia/Baghdad","Asia/Bahrain","Asia/Baku","Asia/Bangkok","Asia/Barnaul","Asia/Beirut","Asia/Bishkek","Asia/Brunei","Asia/Chita","Asia/Choibalsan","Asia/Colombo","Asia/Damascus","Asia/Dhaka","Asia/Dili","Asia/Dubai","Asia/Dushanbe","Asia/Famagusta","Asia/Gaza","Asia/Hebron","Asia/Ho_Chi_Minh","Asia/Hong_Kong","Asia/Hovd","Asia/Irkutsk","Asia/Jakarta","Asia/Jayapura","Asia/Jerusalem","Asia/Kabul","Asia/Kamchatka","Asia/Karachi","Asia/Kathmandu","Asia/Khandyga","Asia/Kolkata","Asia/Krasnoyarsk","Asia/Kuala_Lumpur","Asia/Kuching","Asia/Kuwait","Asia/Macau","Asia/Magadan","Asia/Makassar","Asia/Manila","Asia/Muscat","Asia/Nicosia","Asia/Novokuznetsk","Asia/Novosibirsk","Asia/Omsk","Asia/Oral","Asia/Phnom_Penh","Asia/Pontianak","Asia/Pyongyang","Asia/Qatar","Asia/Qostanay","Asia/Qyzylorda","Asia/Riyadh","Asia/Sakhalin","Asia/Samarkand","Asia/Seoul","Asia/Shanghai","Asia/Singapore","Asia/Srednekolymsk","Asia/Taipei","Asia/Tashkent","Asia/Tbilisi","Asia/Tehran","Asia/Thimphu","Asia/Tokyo","Asia/Tomsk","Asia/Ulaanbaatar","Asia/Urumqi","Asia/Ust-Nera","Asia/Vientiane","Asia/Vladivostok","Asia/Yakutsk","Asia/Yangon","Asia/Yekaterinburg","Asia/Yerevan","Atlantic/Azores","Atlantic/Bermuda","Atlantic/Canary","Atlantic/Cape_Verde","Atlantic/Faroe","Atlantic/Madeira","Atlantic/Reykjavik","Atlantic/South_Georgia","Atlantic/St_Helena","Atlantic/Stanley","Australia/Adelaide","Australia/Brisbane","Australia/Broken_Hill","Australia/Currie","Australia/Darwin","Australia/Eucla","Australia/Hobart","Australia/Lindeman","Australia/Lord_Howe","Australia/Melbourne","Australia/Perth","Australia/Sydney","Europe/Amsterdam","Europe/Andorra","Europe/Astrakhan","Europe/Athens","Europe/Belgrade","Europe/Berlin","Europe/Bratislava","Europe/Brussels","Europe/Bucharest","Europe/Budapest","Europe/Busingen","Europe/Chisinau","Europe/Copenhagen","Europe/Dublin","Europe/Gibraltar","Europe/Guernsey","Europe/Helsinki","Europe/Isle_of_Man","Europe/Istanbul","Europe/Jersey","Europe/Kaliningrad","Europe/Kiev","Europe/Kirov","Europe/Lisbon","Europe/Ljubljana","Europe/London","Europe/Luxembourg","Europe/Madrid","Europe/Malta","Europe/Mariehamn","Europe/Minsk","Europe/Monaco","Europe/Moscow","Europe/Oslo","Europe/Paris","Europe/Podgorica","Europe/Prague","Europe/Riga","Europe/Rome","Europe/Samara","Europe/San_Marino","Europe/Sarajevo","Europe/Saratov","Europe/Simferopol","Europe/Skopje","Europe/Sofia","Europe/Stockholm","Europe/Tallinn","Europe/Tirane","Europe/Ulyanovsk","Europe/Uzhgorod","Europe/Vaduz","Europe/Vatican","Europe/Vienna","Europe/Vilnius","Europe/Volgograd","Europe/Warsaw","Europe/Zagreb","Europe/Zaporozhye","Europe/Zurich","Indian/Antananarivo","Indian/Chagos","Indian/Christmas","Indian/Cocos","Indian/Comoro","Indian/Kerguelen","Indian/Mahe","Indian/Maldives","Indian/Mauritius","Indian/Mayotte","Indian/Reunion","Pacific/Apia","Pacific/Auckland","Pacific/Bougainville","Pacific/Chatham","Pacific/Chuuk","Pacific/Easter","Pacific/Efate","Pacific/Enderbury","Pacific/Fakaofo","Pacific/Fiji","Pacific/Funafuti","Pacific/Galapagos","Pacific/Gambier","Pacific/Guadalcanal","Pacific/Guam","Pacific/Honolulu","Pacific/Kiritimati","Pacific/Kosrae","Pacific/Kwajalein","Pacific/Majuro","Pacific/Marquesas","Pacific/Midway","Pacific/Nauru","Pacific/Niue","Pacific/Norfolk","Pacific/Noumea","Pacific/Pago_Pago","Pacific/Palau","Pacific/Pitcairn","Pacific/Pohnpei","Pacific/Port_Moresby","Pacific/Rarotonga","Pacific/Saipan","Pacific/Tahiti","Pacific/Tarawa","Pacific/Tongatapu","Pacific/Wake","Pacific/Wallis","UTC"]
     default: "UTC"
+  - name: include_file_name
+    label: Include File Name
+    description: Include File Name as a label
+    type: bool
+    default: true
+  - name: include_file_path
+    label: Include File Path
+    description: Include File Path as a label
+    type: bool
+    default: false
+  - name: include_file_name_resolved
+    label: Include Resolved File Name
+    description: Same as include_file_name, however, if file name is a symlink, the underlying file's name will be set as a label
+    type: bool
+    default: false
+  - name: include_file_path_resolved
+    label: Include Resolved File Path
+    description: Same as include_file_path, however, if file path is a symlink, the underlying file's path will be set as a label
+    type: bool
+    default: false
   - name: start_at
     label: Start At
     description: Start reading file from 'beginning' or 'end'
@@ -30,53 +50,36 @@ parameters:
     default: end
 
 # Set Defaults
-# {{$file_path := default "C:/inetpub/logs/LogFiles/W3SVC*/**/*.log" .file_path}}
-# {{$fields := .fields}}
+# {{$include_file_name := default true .include_file_name}}
+# {{$include_file_path := default false .include_file_path}}
+# {{$include_file_name_resolved := default false .include_file_name_resolved}}
+# {{$include_file_path_resolved := default false .include_file_path_resolved}}
 # {{$location := default "UTC" .location}}
 # {{$start_at := default "end" .start_at}}
 
 # Pipeline Template
 pipeline:
-  - id: microsoft_iis_input
-    type: file_input
-    include:
-      - {{ $file_path }}
+  - type: w3c
+    file_log_path:
+# {{ range $i, $fp := .file_log_path  }}
+      - '{{ $fp }}'
+# {{ end }}
+# {{ if .exclude_file_log_path }}
+    exclude:
+  # {{ range $i, $efp := .exclude_file_log_path  }}
+      - '{{ $efp }}'
+  # {{ end }}
+# {{ end }}
+    header_delimiter: " "
+    delimiter: " "
+    include_file_name: {{ $include_file_name }}
+    include_file_path: {{ $include_file_path }}
+    include_file_name_resolved: {{ $include_file_name_resolved }}
+    include_file_path_resolved: {{ $include_file_path_resolved }}
     start_at: {{ $start_at }}
     labels:
       log_type: microsoft_iis
       plugin_id: {{ .id }}
-    output: iis_router
-
-  - id: iis_router
-    type: router
-    routes:
-      - output: quote_handler_parser
-        expr: $record matches '.*".*".*' and not ($record matches "^#")
-      - output: csv_parser
-        expr: 'not ($record matches "^#")'
-      - output: {{ .output }}
-        expr: true
-
-  # Some example log entries have quotes. This will cause an error.
-  # This parses first set of quotes. If more than one set of quotes exist then it will still error.
-  # All examples from logs seen at time of this comment have only contained one set of quotes.
-  - id: quote_handler_parser
-    type: regex_parser
-    parse_from: $record
-    regex: '(?P<message1>[^"]*)(?P<first_quote>[\"])(?P<message2>[^"]*)(?P<second_quote>[\"])(?P<message3>.*)'
-    output: quote_handler_restructurer
-
-  # This will remove the first set of parsed quotes.
-  - id: quote_handler_restructurer
-    type: add
-    field: $record
-    value: 'EXPR($record.message1 + $record.message2 + $record.message3)'
-    output: csv_parser
-
-  - id: csv_parser
-    type: csv_parser
-    delimiter: " "
-    header: {{ $fields }}
 
   # Build timestamp from date and time field if they exist
   - id: add_timestamp

--- a/plugins/microsoft_iis.yaml
+++ b/plugins/microsoft_iis.yaml
@@ -77,9 +77,16 @@ pipeline:
     include_file_name_resolved: {{ $include_file_name_resolved }}
     include_file_path_resolved: {{ $include_file_path_resolved }}
     start_at: {{ $start_at }}
-    labels:
-      log_type: microsoft_iis
-      plugin_id: {{ .id }}
+
+  - id: add_log_type
+    type: add
+    field: '$labels.log_type'
+    value: 'microsoft_iis'
+
+  - id: add_plugin_id
+    type: add
+    field: '$labels.plugin_id'
+    value: '{{.id}}'
 
   # Build timestamp from date and time field if they exist
   - id: add_timestamp

--- a/plugins/microsoft_iis.yaml
+++ b/plugins/microsoft_iis.yaml
@@ -4,11 +4,11 @@ title: Microsoft IIS
 description: Log parser for Microsoft IIS
 min_stanza_version: 1.2.1
 parameters:
-  - name: file_log_path
+  - name: file_path
     label: Log Path
-    description: Specify a single path or multiple paths to read one or many files. You may also use a wildcard (*) to read multiple files within a directory.
-    type: strings
-    default: ["C:/inetpub/logs/LogFiles/W3SVC*/**/*.log"]
+    description: The absolute path to the Microsoft IIS logs
+    type: string
+    default: "C:/inetpub/logs/LogFiles/W3SVC*/**/*.log"
   - name: exclude_file_log_path
     label: Exclude File Path
     description: Specify a single path or multiple paths to exclude one or many files from being read. You may also use a wildcard (*) to exclude multiple files from being read within a directory.
@@ -50,6 +50,7 @@ parameters:
     default: end
 
 # Set Defaults
+# {{$file_path := default "C:/inetpub/logs/LogFiles/W3SVC*/**/*.log" .file_path}}
 # {{$include_file_name := default true .include_file_name}}
 # {{$include_file_path := default false .include_file_path}}
 # {{$include_file_name_resolved := default false .include_file_name_resolved}}
@@ -61,9 +62,7 @@ parameters:
 pipeline:
   - type: w3c
     file_log_path:
-# {{ range $i, $fp := .file_log_path  }}
-      - '{{ $fp }}'
-# {{ end }}
+      - '{{ $file_path }}'
 # {{ if .exclude_file_log_path }}
     exclude:
   # {{ range $i, $efp := .exclude_file_log_path  }}

--- a/plugins/w3c.yaml
+++ b/plugins/w3c.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: W3C
 description: File Input W3C Parser
 min_stanza_version: 1.2.0

--- a/plugins/w3c.yaml
+++ b/plugins/w3c.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.2
+version: 0.0.1
 title: W3C
 description: File Input W3C Parser
 min_stanza_version: 1.2.0
@@ -122,28 +122,6 @@ pipeline:
   #
   - type: filter
     expr: '$record matches "^#"'
-
-  - type: router
-    default: csv_parser
-    routes:
-      - output: quote_handler_parser
-        expr: $record matches '.*".*".*' and not ($record matches "^#")
-
-  # Some example log entries have quotes. This will cause an error.
-  # This parses first set of quotes. If more than one set of quotes exist then it will still error.
-  # All examples from logs seen at time of this comment have only contained one set of quotes.
-  - id: quote_handler_parser
-    type: regex_parser
-    parse_from: $record
-    regex: '(?P<message1>[^"]*)(?P<first_quote>[\"])(?P<message2>[^"]*)(?P<second_quote>[\"])(?P<message3>.*)'
-    output: quote_handler_restructurer
-
-  # This will remove the first set of parsed quotes.
-  - id: quote_handler_restructurer
-    type: add
-    field: $record
-    value: 'EXPR($record.message1 + $record.message2 + $record.message3)'
-    output: csv_parser
 
   # Leverage CSV parser's dynamic field name detection by specifying
   # delimiter, header_delimiter, and header_label

--- a/plugins/w3c.yaml
+++ b/plugins/w3c.yaml
@@ -123,6 +123,28 @@ pipeline:
   - type: filter
     expr: '$record matches "^#"'
 
+  - type: router
+    default: csv_parser
+    routes:
+      - output: quote_handler_parser
+        expr: $record matches '.*".*".*' and not ($record matches "^#")
+
+  # Some example log entries have quotes. This will cause an error.
+  # This parses first set of quotes. If more than one set of quotes exist then it will still error.
+  # All examples from logs seen at time of this comment have only contained one set of quotes.
+  - id: quote_handler_parser
+    type: regex_parser
+    parse_from: $record
+    regex: '(?P<message1>[^"]*)(?P<first_quote>[\"])(?P<message2>[^"]*)(?P<second_quote>[\"])(?P<message3>.*)'
+    output: quote_handler_restructurer
+
+  # This will remove the first set of parsed quotes.
+  - id: quote_handler_restructurer
+    type: add
+    field: $record
+    value: 'EXPR($record.message1 + $record.message2 + $record.message3)'
+    output: csv_parser
+
   # Leverage CSV parser's dynamic field name detection by specifying
   # delimiter, header_delimiter, and header_label
   - type: csv_parser

--- a/test/configs/microsoft_iis/invalid/invalid_location.yaml
+++ b/test/configs/microsoft_iis/invalid/invalid_location.yaml
@@ -1,6 +1,5 @@
 pipeline:
 - type: microsoft_iis
-  file_log_path: 
-    - " "
+  file_path: " "
   location: "Detroit"
 - type: stdout

--- a/test/configs/microsoft_iis/invalid/invalid_location.yaml
+++ b/test/configs/microsoft_iis/invalid/invalid_location.yaml
@@ -1,5 +1,6 @@
 pipeline:
 - type: microsoft_iis
-  fields: 'date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)'
+  file_log_path: 
+    - " "
   location: "Detroit"
 - type: stdout

--- a/test/configs/microsoft_iis/invalid/missing_fields.yaml
+++ b/test/configs/microsoft_iis/invalid/missing_fields.yaml
@@ -1,3 +1,0 @@
-pipeline:
-- type: microsoft_iis
-- type: stdout

--- a/test/configs/microsoft_iis/valid/full.yaml
+++ b/test/configs/microsoft_iis/valid/full.yaml
@@ -1,7 +1,6 @@
 pipeline:
 - type: microsoft_iis
-  file_log_path: 
-    - "C:/inetpub/logs/W3SVC*/**/*.log"
+  file_path: "C:/inetpub/logs/W3SVC*/**/*.log"
   exclude_file_log_path:
     - " "
   location: "America/Detroit"

--- a/test/configs/microsoft_iis/valid/full.yaml
+++ b/test/configs/microsoft_iis/valid/full.yaml
@@ -1,7 +1,13 @@
 pipeline:
 - type: microsoft_iis
-  file_path: "C:/inetpub/logs/W3SVC*/**/*.log"
-  fields: 'date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)'
+  file_log_path: 
+    - "C:/inetpub/logs/W3SVC*/**/*.log"
+  exclude_file_log_path:
+    - " "
   location: "America/Detroit"
   start_at: end
+  include_file_name: true
+  include_file_path: false
+  include_file_name_resolved: false
+  include_file_path_resolved: false
 - type: stdout

--- a/test/configs/microsoft_iis/valid/minimal.yaml
+++ b/test/configs/microsoft_iis/valid/minimal.yaml
@@ -1,5 +1,4 @@
 pipeline:
 - type: microsoft_iis
-  file_log_path: 
-    - " "
+  file_path: " "
 - type: stdout

--- a/test/configs/microsoft_iis/valid/minimal.yaml
+++ b/test/configs/microsoft_iis/valid/minimal.yaml
@@ -1,4 +1,5 @@
 pipeline:
 - type: microsoft_iis
-  fields: 'date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)'
+  file_log_path: 
+    - " "
 - type: stdout


### PR DESCRIPTION
Update IIS plugin to use new w3c plugin. This will reduce complexity of setup. You no longer need to specify the fields. It will now read it dynamically from the log header.

- Parameter Changes
  - `file_path` is now  `file_log_path` and uses array of strings
  - Removed `fields` it is now dynamic generated from file.
  - Added `include_file_name`, `include_file_path`, `include_file_name_resolved`, and `include_file_path_resolved`

### Output

``` json
{
  "timestamp": "2020-11-03T16:13:15-05:00",
  "severity": 50,
  "severity_text": "404",
  "labels": {
    "Date": "2020-11-03 16:13:15",
    "Software": "Microsoft Internet Information Services 10.0",
    "Version": "1.0",
    "file_name": "iis.log",
    "log_type": "microsoft_iis",
    "plugin_id": "microsoft_iis"
  },
  "record": {
    "c-ip": "10.0.0.1",
    "cs(Referer)": "-",
    "cs(User-Agent)": "Go-http-client/1.1",
    "cs-method": "GET",
    "cs-uri-query": "-",
    "cs-uri-stem": "/status",
    "cs-username": "-",
    "s-ip": "10.0.0.11",
    "s-port": "80",
    "sc-status": "404",
    "sc-substatus": "0",
    "sc-win32-status": "2",
    "time-taken": "1"
  }
}
```