### PR TITLE
Move quote handler to w3c from microsoft_iis plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.74] - Unreleased
+
+### Changed
+
+- Updated `w3c` plugin ([PR316](https://github.com/observIQ/stanza-plugins/pull/316))
+  - Add quote parsing from iis to handle when a pair of single quotes are in the log entry.
+
 ## [0.0.73] - 2021-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated `w3c` plugin ([PR316](https://github.com/observIQ/stanza-plugins/pull/316))
+- Updated `w3c` plugin ([PR318](https://github.com/observIQ/stanza-plugins/pull/318))
   - Add quote parsing from iis to handle when a pair of single quotes are in the log entry.
 
 ## [0.0.73] - 2021-09-02

--- a/plugins/w3c.yaml
+++ b/plugins/w3c.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: W3C
 description: File Input W3C Parser
 min_stanza_version: 1.2.0
@@ -122,6 +122,28 @@ pipeline:
   #
   - type: filter
     expr: '$record matches "^#"'
+
+  - type: router
+    default: csv_parser
+    routes:
+      - output: quote_handler_parser
+        expr: $record matches '.*".*".*' and not ($record matches "^#")
+
+  # Some example log entries have quotes. This will cause an error.
+  # This parses first set of quotes. If more than one set of quotes exist then it will still error.
+  # All examples from logs seen at time of this comment have only contained one set of quotes.
+  - id: quote_handler_parser
+    type: regex_parser
+    parse_from: $record
+    regex: '(?P<message1>[^"]*)(?P<first_quote>[\"])(?P<message2>[^"]*)(?P<second_quote>[\"])(?P<message3>.*)'
+    output: quote_handler_restructurer
+
+  # This will remove the first set of parsed quotes.
+  - id: quote_handler_restructurer
+    type: add
+    field: $record
+    value: 'EXPR($record.message1 + $record.message2 + $record.message3)'
+    output: csv_parser
 
   # Leverage CSV parser's dynamic field name detection by specifying
   # delimiter, header_delimiter, and header_label

--- a/plugins/w3c.yaml
+++ b/plugins/w3c.yaml
@@ -132,6 +132,9 @@ pipeline:
   # Some example log entries have quotes. This will cause an error.
   # This parses first set of quotes. If more than one set of quotes exist then it will still error.
   # All examples from logs seen at time of this comment have only contained one set of quotes.
+  # Example:
+  # #Fields: date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)
+  # 2021-06-14 18:36:47 0.0.0.0 OutboundConnectionResponse SMTPSVC1 TSIC-PHOENIX - 25 - - 354+3.0.0+continue.++finished+with+"\r\n.\r\n" 0 0 46 0 531 SMTP - - - -
   - id: quote_handler_parser
     type: regex_parser
     parse_from: $record


### PR DESCRIPTION
 Some log entries have quotes. This will cause an error. This PR adds ability to parse first set of quotes. It will still error if there are more than one set of quotes.  I haven't seen any examples of multiple quotes in a log entry. This fix was moved from IIS plugin to w3c.
