### PR TITLE
add metadata labels to all tcp / udp based plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.74] - Unreleased
 
+## Changed
+
+- Added net.transport, net.peer.ip, net.peer.port, net.host.ip and net.host.port labels to all tcp / udp plugins ([PR320](https://github.com/observIQ/stanza-plugins/pull/320))
+  - cisco_asa, cisco_meraki, rsyslog, syslog, syslogng, ubiquiti, vmware_esxi, vmware_vcenter
+
 ## Fixed 
 
 - Issue #[314](https://github.com/observIQ/stanza-plugins/issues/314) for nodejs  ([PR315](https://github.com/observIQ/stanza-plugins/pull/315))

--- a/plugins/cisco_asa.yaml
+++ b/plugins/cisco_asa.yaml
@@ -20,6 +20,7 @@ pipeline:
     labels:
       log_type: cisco_asa
       plugin_id: {{ .id }}
+    add_labels: true
     output: cisco_parser
 
   - id: cisco_parser

--- a/plugins/cisco_meraki.yaml
+++ b/plugins/cisco_meraki.yaml
@@ -20,6 +20,7 @@ pipeline:
     labels:
       log_type: cisco_meraki
       plugin_id: {{ .id }}
+    add_labels: true
 
   - id: regex_router
     type: router

--- a/plugins/netmotion.yaml
+++ b/plugins/netmotion.yaml
@@ -21,6 +21,7 @@ pipeline:
     labels:
       log_type: netmotion
       plugin_id: {{ .id }}
+    add_labels: true
     output: handle_new_lines
 
   # tcp input uses \n to break messages into seperate

--- a/plugins/rsyslog.yaml
+++ b/plugins/rsyslog.yaml
@@ -49,6 +49,7 @@ pipeline:
     labels:
       log_type: rsyslog
       plugin_id: {{ .id }}
+    add_labels: true
     output: rsyslog_parser
 # {{ end }}
 
@@ -59,6 +60,7 @@ pipeline:
     labels:
       log_type: rsyslog
       plugin_id: {{ .id }}
+    add_labels: true
     output: rsyslog_parser
 # {{ end }}
 

--- a/plugins/syslog.yaml
+++ b/plugins/syslog.yaml
@@ -49,6 +49,7 @@ pipeline:
     labels:
       log_type: syslog
       plugin_id: {{ .id }}
+    add_labels: true
     output: syslog_parser
 # {{ end }}
 
@@ -59,6 +60,7 @@ pipeline:
     labels:
       log_type: syslog
       plugin_id: {{ .id }}
+    add_labels: true
     output: syslog_parser
 # {{ end }}
 

--- a/plugins/syslogng.yaml
+++ b/plugins/syslogng.yaml
@@ -49,6 +49,7 @@ pipeline:
     labels:
       log_type: syslogng
       plugin_id: {{ .id }}
+    add_labels: true
     output: syslogng_parser
 # {{ end }}
 
@@ -59,6 +60,7 @@ pipeline:
     labels:
       log_type: syslogng
       plugin_id: {{ .id }}
+    add_labels: true
     output: syslogng_parser
 # {{ end }}
 

--- a/plugins/ubiquiti.yaml
+++ b/plugins/ubiquiti.yaml
@@ -27,6 +27,7 @@ pipeline:
     labels:
       log_type: ubiquiti
       plugin_id: {{ .id }}
+    add_labels: true
     output: device_router
   
   - id: device_router

--- a/plugins/vmware_esxi.yaml
+++ b/plugins/vmware_esxi.yaml
@@ -46,6 +46,7 @@ pipeline:
     labels:
       log_type: vmware_esxi
       plugin_id: {{ .id }}
+    add_labels: true
     tls:
       enable: {{ $enable_tls }}
       certificate: {{ $certificate_file }}

--- a/plugins/vmware_vcenter.yaml
+++ b/plugins/vmware_vcenter.yaml
@@ -55,6 +55,7 @@ pipeline:
     labels:
       log_type: vmware_vcenter
       plugin_id: {{ .id }}
+    add_labels: true
     tls:
       enable: {{ $enable_tls }}
       certificate: {{ $certificate_file }}


### PR DESCRIPTION
TCP and UDP input operators have a new `add_labels` option that must be explicitly enabled. 
- https://github.com/observIQ/stanza/blob/master/docs/operators/tcp_input.md
- https://github.com/observIQ/stanza/blob/master/docs/operators/udp_input.md