### PR TITLE
W3c max concurrent files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.78] - Unreleased
+
+- W3C: Added max_concurrent_files parameter ([PR332](https://github.com/observIQ/stanza-plugins/pull/332))
+
 ## [0.0.77] - 2021-09-14
 
 ### Changed

--- a/plugins/w3c.yaml
+++ b/plugins/w3c.yaml
@@ -47,6 +47,12 @@ parameters:
     relevant_if:
       start_at:
         equals: "beginning"
+  - name: max_concurrent_files
+    label: Max Concurrent File
+    description: Max number of W3C files that will be open during a polling cycle
+    type: int
+    default: 512
+    advanced_config: true
   - name: include_file_name
     label: Include File Name
     description: Include File Name as a label
@@ -87,6 +93,7 @@ parameters:
 # {{$log_type := default "w3c" .log_type}}
 # {{$start_at := default "end" .start_at}}
 # {{$delete_after_read := default false .delete_after_read}}
+# {{$max_concurrent_files := default 512 .max_concurrent_files}}
 # {{$include_file_name := default true .include_file_name}}
 # {{$include_file_path := default false .include_file_path}}
 # {{$include_file_name_resolved := default false .include_file_name_resolved}}
@@ -100,6 +107,7 @@ pipeline:
   - type: file_input
     start_at: '{{ $start_at }}'
     delete_after_read: {{ $delete_after_read }}
+    max_concurrent_files: {{ $max_concurrent_files }}
     label_regex: '^#(?P<key>.*?): (?P<value>.*)'
     include_file_name: {{ $include_file_name }}
     include_file_path: {{ $include_file_path }}

--- a/test/configs/w3c/valid/full.yaml
+++ b/test/configs/w3c/valid/full.yaml
@@ -16,4 +16,5 @@ pipeline:
   fields_header: LogFields
   delimiter: "-"
   header_delimiter: ":"
+  max_concurrent_files: 1000
 - type: stdout


### PR DESCRIPTION
Max concurrent files is a file_input parameter that defaults to 512. https://github.com/observIQ/stanza/blob/master/docs/operators/file_input.md

In some cases, the user will want to control this value, so we need to expose it in the plugin.