### PR TITLE
Add HAProxy Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.78] - Unreleased
 
+### Added
+
+- Added haproxy plugin ([334](https://github.com/observIQ/stanza-plugins/pull/334))
+
 ### Changed
 
 - W3C: Added max_concurrent_files parameter ([PR332](https://github.com/observIQ/stanza-plugins/pull/332))

--- a/plugins/haproxy.yaml
+++ b/plugins/haproxy.yaml
@@ -61,12 +61,8 @@ pipeline:
     routes:
       - output: httplog_parser
         expr: '$record.message != nill and $record.message matches "^(\\s)?[^:]+:[^\\s]+\\s+\\[[^\\]]+\\]\\s+[^\\s]+\\s+[^/]+/[^\\s]+\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[\\w-]{4}\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^/]+/[^\\s]+\\s+"'
-        labels:
-          log_type: 'haproxy.http'
       - output: tcplog_parser
         expr: '$record.message != nil and $record.message matches "^(\\s)?[^:]+:[^\\s]+\\s+\\[[^\\]]+\\]\\s+[^\\s]+\\s+[^/]+/[^\\s]+\\s+[^/]+/[^/]+/[^\\s]+\\s+[^\\s]+\\s+[\\w-]{2}\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^/]+/[\\d]+"'
-        labels:
-          log_type: 'haproxy.tcp'
       - output: error_parser
         expr: '$record.message != nil and $record.message matches "^\\s*\\[[^\\]]+\\]\\s*.*"'
         labels:
@@ -114,8 +110,6 @@ pipeline:
     routes:
       - output: observiq_parser
         expr: '$record.message != nil and $record.message matches "^{.*}$|^{.*}\\n$"'
-        labels:
-          log_type: 'haproxy.observiq'
       - output: error_parser
         expr: '$record.message != nil and $record.message matches "^\\s*\\[[^\\]]+\\]\\s*.*"'
         labels:
@@ -184,14 +178,17 @@ pipeline:
     to: '$labels["frontend_ssl_ciphers"]'
   - id: method_move
     type: move
+    if: '$record.method != nil'
     from: '$record.method'
     to: '$labels["method"]'
   - id: protocol_move
     type: move
+    if: '$record.protocol != nil'
     from: '$record.protocol'
     to: '$labels["protocol"]'
   - id: protocol_version_move
     type: move
+    if: '$record.protocol_version != nil'
     from: '$record.protocol_version'
     to: '$labels["protocol_version"]'
   - id: referer_move
@@ -203,10 +200,12 @@ pipeline:
   # Promote fields to resources
   - id: frontend_type_move
     type: move
+    if: '$record.frontend_type != nil'
     from: '$record.frontend_type'
     to: '$resource["frontend_type"]'
   - id: frontend_ip_move
     type: move
+    if: '$record.frontend_ip != nil'
     from: '$record.frontend_ip'
     to: '$resource["frontend_ip"]'
   - id: path_move
@@ -226,15 +225,17 @@ pipeline:
     to: '$resource["frontend_name"]'
   - id: backend_name_move
     type: move
+    if: '$record.backend_name != nil'
     from: '$record.backend_name'
     to: '$resource["backend_name"]'
   - id: server_name_move
     type: move
+    if: '$record.server_name != nil'
     from: '$record.server_name'
     to: '$resource["server_name"]'
   - id: host_move
     type: move
-    # if: $record.message != nil and $record.host == nil
+    if: '$record.host != nil'
     from: '$record.host'
     to: '$resource["host"]'
     output: {{ .output }}

--- a/plugins/haproxy.yaml
+++ b/plugins/haproxy.yaml
@@ -1,0 +1,112 @@
+version: 0.0.1
+title: HAProxy
+description: Log parser for HAProxy
+parameters:
+  - name: file_log_path
+    label: File Path
+    description: Specify a single path or multiple paths to read one or many files. You may also use a wildcard (*) to read multiple files within a directory.
+    type: strings
+    required: true
+  - name: log_format
+    label: Log Format
+    description: When choosing the 'default' option, the agent will expect and parse logs in a format of HTTP or TCP as well as any log entries that matches the default logging configuration. HAProxy uses default logging format when no specific option is set. When choosing the 'observIQ' option, the agent will expect and parse logs in an optimized JSON format that adheres to the observIQ specification, requiring an update to the Log-Format for each mode. See the HAProxy source page for more information.
+    type: enum
+    valid_values:
+      - http
+      - tcp
+      - observiq
+    default: http
+  - name: start_at
+    label: Start At
+    description: Start reading file from 'beginning' or 'end'
+    type: enum
+    valid_values:
+     - beginning
+     - end
+    default: end
+# Set Defaults
+#{{$start_at := default "end" .start_at}}
+# {{$log_format := default "default" .log_format}}
+pipeline:
+  - id: log_reader
+    type: file_input
+    include:
+    # {{ range $i, $fp := .file_log_path  }}
+      - '{{ $fp }}'
+    # {{ end }}
+    start_at: {{ $start_at }}
+    labels:
+      log_type: 'haproxy'
+      plugin_id: {{ .id }}
+    write_to: message
+
+  # Parse timestamp, host, and message.
+  - id: default_parser
+    if: '$record.message != nil and $record.message matches "^\\w{3}\\s+\\d{1,2}\\s+\\d{2}:\\d{2}:\\d{2}\\s+[^\\s]+\\s+[^\\[]+\\[[^\\]]+\\]:"'
+    type: regex_parser
+    parse_from: $record.message
+    regex: '^(?P<timestamp>\w{3}\s+\d{2}\s+\d{2}:\d{2}:\d{2})\s+(?P<host>[^\s]+)\s+(?P<process_name>[^\[]+)\[(?P<pid>[^\]]+)\]:(\s)?(?P<message>.*)'
+    timestamp:
+      parse_from: timestamp
+      layout_type: gotime
+      layout: 'Jan 02 15:04:05'
+
+  # Parse http format log message
+  # {{ if eq $log_format "http" }}
+  - id: httplog_parser
+    if: '$record.message != nill and $record.message matches "^(\\s)?[^:]+:[^\\s]+\\s+\\[[^\\]]+\\]\\s+[^\\s]+\\s+[^/]+/[^\\s]+\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[\\w-]{4}\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^/]+/[^\\s]+\\s+"'
+    type: regex_parser
+    parse_from: $record.message
+    regex: '^(\s)?(?P<client_ip>[^:]+):(?P<client_port>[^\s]+)\s+\[(?P<accept_date>[^\]]+)\]\s+(?P<frontend_name>[^\s]+)\s+(?P<backend_name>[^/]+)/(?P<server_name>[^\s]+)\s+(?P<client_request_send_time>[^/]+)/(?P<queue_wait_time>[^/]+)/(?P<server_response_time>[^/]+)/(?P<server_response_send_time>[^/]+)/(?P<client_request_active_time>[^\s]+)\s+(?P<status>[^\s]+)\s+(?P<bytes_read>[^\s]+)\s+(?P<captured_request_cookie>[^\s]+)\s+(?P<captured_response_cookie>[^\s]+)\s+(?P<termination_state>[\w-]{4})\s+(?P<process_concurrent_connections>[^/]+)/(?P<frontend_concurrent_connections>[^/]+)/(?P<backend_concurrent_connections>[^/]+)/(?P<server_concurrent_connections>[^/]+)/(?P<server_connection_retries>[^\s]+)\s+(?P<server_queue>[^/]+)/(?P<backend_queue>[^\s]+)\s+"(?P<method>\S+) +(?P<path>[^ ]*)( (?P<protocol>[^/]*)/(?P<protocol_version>[^\"]*)|[^\"]*)?"'
+  
+  - id: add_label_http
+    type: add
+    field: $labels.log_type
+    value: 'haproxy.http'
+  # {{ end }}
+
+  # Parse tcp format log message
+  # {{ if eq $log_format "tcp" }}
+  - id: tcplog_parser
+    if: '$record.message != nil and $record.message matches "^(\\s)?[^:]+:[^\\s]+\\s+\\[[^\\]]+\\]\\s+[^\\s]+\\s+[^/]+/[^\\s]+\\s+[^/]+/[^/]+/[^\\s]+\\s+[^\\s]+\\s+[\\w-]{2}\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^/]+/[\\d]+"'
+    type: regex_parser
+    parse_from: $record.message
+    regex: '^(\s)?(?P<client_ip>[^:]+):(?P<client_port>[^\s]+)\s+\[(?P<accept_date>[^\]]+)\]\s+(?P<frontend_name>[^\s]+)\s+(?P<backend_name>[^/]+)/(?P<server_name>[^\s]+)\s+(?P<queue_wait_time>[^/]+)/(?P<server_response_time>[^/]+)/(?P<session_duration>[^\s]+)\s+(?P<bytes_read>[^\s]+)\s+(?P<termination_state>[\w-]{2})\s+(?P<process_concurrent_connections>[^/]+)/(?P<frontend_concurrent_connections>[^/]+)/(?P<backend_concurrent_connections>[^/]+)/(?P<server_concurrent_connections>[^/]+)/(?P<server_connection_retries>[^\s]+)\s+(?P<server_queue>[^/]+)/(?P<backend_queue>[\d]+)'
+
+  - id: add_label_tcp
+    type: add
+    field: $labels.log_type
+    value: 'haproxy.tcp'
+  # {{ end }}
+
+  # Parse observiq format log message
+  # {{ if eq $log_format "observiq" }}
+  - id: json_parser
+    type: json_parser
+    if: '$record.message != nil and $record.message matches "^{.*}$|^{.*}\\n$"'
+    parse_from: $record.message
+
+  - id: add_label_observiq
+    type: add
+    field: $labels.log_type
+    value: 'haproxy.observiq'
+  # {{ end }}
+
+  # Parse status if it exists
+  - type: severity_parser
+    if: '$record.status != nil'
+    parse_from: $record.status
+    preserve_to: $record.status
+    preset: none
+    mapping:
+      info: 2xx
+      notice: 3xx
+      warning: 4xx
+      error: 5xx
+
+  # If $record.message still exists and $record.host doesn't that means we were unable to parse and just need to promote to $record
+  - type: move
+    if: $record.message != nil and $record.host == nil
+    from: $record.message
+    to: $record
+    output: {{ .output }}

--- a/plugins/haproxy.yaml
+++ b/plugins/haproxy.yaml
@@ -60,7 +60,7 @@ pipeline:
     default: message_move
     routes:
       - output: httplog_parser
-        expr: '$record.message != nill and $record.message matches "^(\\s)?[^:]+:[^\\s]+\\s+\\[[^\\]]+\\]\\s+[^\\s]+\\s+[^/]+/[^\\s]+\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[\\w-]{4}\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^/]+/[^\\s]+\\s+"'
+        expr: '$record.message != nil and $record.message matches "^(\\s)?[^:]+:[^\\s]+\\s+\\[[^\\]]+\\]\\s+[^\\s]+\\s+[^/]+/[^\\s]+\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[\\w-]{4}\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^/]+/[^\\s]+\\s+"'
       - output: tcplog_parser
         expr: '$record.message != nil and $record.message matches "^(\\s)?[^:]+:[^\\s]+\\s+\\[[^\\]]+\\]\\s+[^\\s]+\\s+[^/]+/[^\\s]+\\s+[^/]+/[^/]+/[^\\s]+\\s+[^\\s]+\\s+[\\w-]{2}\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^/]+/[\\d]+"'
       - output: error_parser

--- a/plugins/haproxy.yaml
+++ b/plugins/haproxy.yaml
@@ -1,6 +1,9 @@
 version: 0.0.1
 title: HAProxy
 description: Log parser for HAProxy
+supported_platforms:
+  - linux
+min_stanza_version: 0.14.0
 parameters:
   - name: file_log_path
     label: File Path

--- a/plugins/haproxy.yaml
+++ b/plugins/haproxy.yaml
@@ -76,7 +76,7 @@ pipeline:
   - id: httplog_parser
     type: regex_parser
     parse_from: $record.message
-    regex: '^(\s)?(?P<frontend_ip>[^:]+):(?P<frontend_port>[^\s]+)\s+\[(?P<accept_date>[^\]]+)\]\s+(?P<frontend_name>[^\s]+)\s+(?P<backend_name>[^/]+)/(?P<server_name>[^\s]+)\s+(?P<client_request_send_time>[^/]+)/(?P<queue_wait_time>[^/]+)/(?P<response_time>[^/]+)/(?P<response_send_time>[^/]+)/(?P<client_request_active_time>[^\s]+)\s+(?P<status>[^\s]+)\s+(?P<bytes_read>[^\s]+)\s+(?P<captured_request_cookie>[^\s]+)\s+(?P<captured_response_cookie>[^\s]+)\s+(?P<termination_state>[\w-]{4})\s+(?P<process_concurrent_connections>[^/]+)/(?P<frontend_concurrent_connections>[^/]+)/(?P<backend_concurrent_connections>[^/]+)/(?P<server_concurrent_connections>[^/]+)/(?P<retries>[^\s]+)\s+(?P<server_queue>[^/]+)/(?P<backend_queue>[^\s]+)\s+"(?P<method>\S+) +(?P<uri>[^ ]*)( (?P<protocol>[^/]*)/(?P<protocol_version>[^\"]*)|[^\"]*)?"'
+    regex: '^(\s)?(?P<frontend_ip>[^:]+):(?P<frontend_port>[^\s]+)\s+\[(?P<accept_date>[^\]]+)\]\s+(?P<frontend_name_transport>[^\s]+)\s+(?P<backend_name>[^/]+)/(?P<server_name>[^\s]+)\s+(?P<client_request_send_time>[^/]+)/(?P<queue_wait_time>[^/]+)/(?P<response_time>[^/]+)/(?P<response_send_time>[^/]+)/(?P<client_request_active_time>[^\s]+)\s+(?P<status>[^\s]+)\s+(?P<bytes_read>[^\s]+)\s+(?P<captured_request_cookie>[^\s]+)\s+(?P<captured_response_cookie>[^\s]+)\s+(?P<termination_state>[\w-]{4})\s+(?P<process_concurrent_connections>[^/]+)/(?P<frontend_concurrent_connections>[^/]+)/(?P<backend_concurrent_connections>[^/]+)/(?P<server_concurrent_connections>[^/]+)/(?P<retries>[^\s]+)\s+(?P<server_queue>[^/]+)/(?P<backend_queue>[^\s]+)\s+"(?P<method>\S+) +(?P<uri>[^ ]*)( (?P<protocol>[^/]*)/(?P<protocol_version>[^\"]*)|[^\"]*)?"'
     output: frontend_type_http_add
 
   - id: frontend_type_http_add
@@ -89,7 +89,7 @@ pipeline:
   - id: tcplog_parser
     type: regex_parser
     parse_from: $record.message
-    regex: '^(\s)?(?P<frontend_ip>[^:]+):(?P<frontend_port>[^\s]+)\s+\[(?P<accept_date>[^\]]+)\]\s+(?P<frontend_name>[^\s]+)\s+(?P<backend_name>[^/]+)/(?P<server_name>[^\s]+)\s+(?P<queue_wait_time>[^/]+)/(?P<server_response_time>[^/]+)/(?P<session_duration>[^\s]+)\s+(?P<bytes_read>[^\s]+)\s+(?P<termination_state>[\w-]{2})\s+(?P<process_concurrent_connections>[^/]+)/(?P<frontend_concurrent_connections>[^/]+)/(?P<backend_concurrent_connections>[^/]+)/(?P<server_concurrent_connections>[^/]+)/(?P<retries>[^\s]+)\s+(?P<server_queue>[^/]+)/(?P<backend_queue>[\d]+)'
+    regex: '^(\s)?(?P<frontend_ip>[^:]+):(?P<frontend_port>[^\s]+)\s+\[(?P<accept_date>[^\]]+)\]\s+(?P<frontend_name_transport>[^\s]+)\s+(?P<backend_name>[^/]+)/(?P<server_name>[^\s]+)\s+(?P<queue_wait_time>[^/]+)/(?P<server_response_time>[^/]+)/(?P<session_duration>[^\s]+)\s+(?P<bytes_read>[^\s]+)\s+(?P<termination_state>[\w-]{2})\s+(?P<process_concurrent_connections>[^/]+)/(?P<frontend_concurrent_connections>[^/]+)/(?P<backend_concurrent_connections>[^/]+)/(?P<server_concurrent_connections>[^/]+)/(?P<retries>[^\s]+)\s+(?P<server_queue>[^/]+)/(?P<backend_queue>[\d]+)'
     output: frontend_type_tcp_add
 
   - id: frontend_type_tcp_add
@@ -221,6 +221,7 @@ pipeline:
     to: '$resource["query_parameters"]'
   - id: frontend_name_move
     type: move
+    if: '$record.frontend_name != nil'
     from: '$record.frontend_name'
     to: '$resource["frontend_name"]'
   - id: backend_name_move
@@ -237,7 +238,7 @@ pipeline:
     from: '$record.host'
     to: '$resource["host"]'
     output: {{ .output }}
-  
+
   # Parser error logs
   # Severities: emerg alert crit err warning notice info debug
   - id: error_parser

--- a/plugins/haproxy.yaml
+++ b/plugins/haproxy.yaml
@@ -3,7 +3,7 @@ title: HAProxy
 description: Log parser for HAProxy
 supported_platforms:
   - linux
-min_stanza_version: 0.14.0
+min_stanza_version: 1.2.6
 parameters:
   - name: file_log_path
     label: File Path
@@ -12,13 +12,12 @@ parameters:
     required: true
   - name: log_format
     label: Log Format
-    description: When choosing the 'default' option, the agent will expect and parse logs in a format of HTTP or TCP as well as any log entries that matches the default logging configuration. HAProxy uses default logging format when no specific option is set. When choosing the 'observIQ' option, the agent will expect and parse logs in an optimized JSON format that adheres to the observIQ specification, requiring an update to the Log-Format for each mode. See the HAProxy source page for more information.
+    description: When choosing the 'default' option, the agent will expect and parse logs in a format of HTTP or TCP as well as any log entries that matches the default or error logging configuration. HAProxy uses default logging format when no specific option is set. When choosing the 'observIQ' option, the agent will expect and parse logs in an optimized JSON format that adheres to the observIQ specification, requiring an update to the Log-Format for each mode. See the HAProxy source page for more information.
     type: enum
     valid_values:
-      - http
-      - tcp
+      - default
       - observiq
-    default: http
+    default: default
   - name: start_at
     label: Start At
     description: Start reading file from 'beginning' or 'end'
@@ -28,7 +27,7 @@ parameters:
      - end
     default: end
 # Set Defaults
-#{{$start_at := default "end" .start_at}}
+# {{$start_at := default "end" .start_at}}
 # {{$log_format := default "default" .log_format}}
 pipeline:
   - id: log_reader
@@ -54,49 +53,86 @@ pipeline:
       layout_type: gotime
       layout: 'Jan 02 15:04:05'
 
+  # {{ if eq $log_format "default" }}
+  # Route to correct parser
+  - id: message_router
+    type: router
+    default: message_move
+    routes:
+      - output: httplog_parser
+        expr: '$record.message != nill and $record.message matches "^(\\s)?[^:]+:[^\\s]+\\s+\\[[^\\]]+\\]\\s+[^\\s]+\\s+[^/]+/[^\\s]+\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[\\w-]{4}\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^/]+/[^\\s]+\\s+"'
+        labels:
+          log_type: 'haproxy.http'
+      - output: tcplog_parser
+        expr: '$record.message != nil and $record.message matches "^(\\s)?[^:]+:[^\\s]+\\s+\\[[^\\]]+\\]\\s+[^\\s]+\\s+[^/]+/[^\\s]+\\s+[^/]+/[^/]+/[^\\s]+\\s+[^\\s]+\\s+[\\w-]{2}\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^/]+/[\\d]+"'
+        labels:
+          log_type: 'haproxy.tcp'
+      - output: error_parser
+        expr: '$record.message != nil and $record.message matches "^\\s*\\[[^\\]]+\\]\\s*.*"'
+        labels:
+          log_type: 'haproxy.error'
+
   # Parse http format log message
-  # {{ if eq $log_format "http" }}
   - id: httplog_parser
-    if: '$record.message != nill and $record.message matches "^(\\s)?[^:]+:[^\\s]+\\s+\\[[^\\]]+\\]\\s+[^\\s]+\\s+[^/]+/[^\\s]+\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+[\\w-]{4}\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^/]+/[^\\s]+\\s+"'
     type: regex_parser
     parse_from: $record.message
-    regex: '^(\s)?(?P<client_ip>[^:]+):(?P<client_port>[^\s]+)\s+\[(?P<accept_date>[^\]]+)\]\s+(?P<frontend_name>[^\s]+)\s+(?P<backend_name>[^/]+)/(?P<server_name>[^\s]+)\s+(?P<client_request_send_time>[^/]+)/(?P<queue_wait_time>[^/]+)/(?P<server_response_time>[^/]+)/(?P<server_response_send_time>[^/]+)/(?P<client_request_active_time>[^\s]+)\s+(?P<status>[^\s]+)\s+(?P<bytes_read>[^\s]+)\s+(?P<captured_request_cookie>[^\s]+)\s+(?P<captured_response_cookie>[^\s]+)\s+(?P<termination_state>[\w-]{4})\s+(?P<process_concurrent_connections>[^/]+)/(?P<frontend_concurrent_connections>[^/]+)/(?P<backend_concurrent_connections>[^/]+)/(?P<server_concurrent_connections>[^/]+)/(?P<server_connection_retries>[^\s]+)\s+(?P<server_queue>[^/]+)/(?P<backend_queue>[^\s]+)\s+"(?P<method>\S+) +(?P<path>[^ ]*)( (?P<protocol>[^/]*)/(?P<protocol_version>[^\"]*)|[^\"]*)?"'
-  
-  - id: add_label_http
+    regex: '^(\s)?(?P<frontend_ip>[^:]+):(?P<frontend_port>[^\s]+)\s+\[(?P<accept_date>[^\]]+)\]\s+(?P<frontend_name>[^\s]+)\s+(?P<backend_name>[^/]+)/(?P<server_name>[^\s]+)\s+(?P<client_request_send_time>[^/]+)/(?P<queue_wait_time>[^/]+)/(?P<response_time>[^/]+)/(?P<response_send_time>[^/]+)/(?P<client_request_active_time>[^\s]+)\s+(?P<status>[^\s]+)\s+(?P<bytes_read>[^\s]+)\s+(?P<captured_request_cookie>[^\s]+)\s+(?P<captured_response_cookie>[^\s]+)\s+(?P<termination_state>[\w-]{4})\s+(?P<process_concurrent_connections>[^/]+)/(?P<frontend_concurrent_connections>[^/]+)/(?P<backend_concurrent_connections>[^/]+)/(?P<server_concurrent_connections>[^/]+)/(?P<retries>[^\s]+)\s+(?P<server_queue>[^/]+)/(?P<backend_queue>[^\s]+)\s+"(?P<method>\S+) +(?P<uri>[^ ]*)( (?P<protocol>[^/]*)/(?P<protocol_version>[^\"]*)|[^\"]*)?"'
+    output: frontend_type_http_add
+
+  - id: frontend_type_http_add
     type: add
-    field: $labels.log_type
-    value: 'haproxy.http'
-  # {{ end }}
+    field: frontend_type
+    value: http
+    output: status_severity_parser
 
   # Parse tcp format log message
-  # {{ if eq $log_format "tcp" }}
   - id: tcplog_parser
-    if: '$record.message != nil and $record.message matches "^(\\s)?[^:]+:[^\\s]+\\s+\\[[^\\]]+\\]\\s+[^\\s]+\\s+[^/]+/[^\\s]+\\s+[^/]+/[^/]+/[^\\s]+\\s+[^\\s]+\\s+[\\w-]{2}\\s+[^/]+/[^/]+/[^/]+/[^/]+/[^\\s]+\\s+[^/]+/[\\d]+"'
     type: regex_parser
     parse_from: $record.message
-    regex: '^(\s)?(?P<client_ip>[^:]+):(?P<client_port>[^\s]+)\s+\[(?P<accept_date>[^\]]+)\]\s+(?P<frontend_name>[^\s]+)\s+(?P<backend_name>[^/]+)/(?P<server_name>[^\s]+)\s+(?P<queue_wait_time>[^/]+)/(?P<server_response_time>[^/]+)/(?P<session_duration>[^\s]+)\s+(?P<bytes_read>[^\s]+)\s+(?P<termination_state>[\w-]{2})\s+(?P<process_concurrent_connections>[^/]+)/(?P<frontend_concurrent_connections>[^/]+)/(?P<backend_concurrent_connections>[^/]+)/(?P<server_concurrent_connections>[^/]+)/(?P<server_connection_retries>[^\s]+)\s+(?P<server_queue>[^/]+)/(?P<backend_queue>[\d]+)'
+    regex: '^(\s)?(?P<frontend_ip>[^:]+):(?P<frontend_port>[^\s]+)\s+\[(?P<accept_date>[^\]]+)\]\s+(?P<frontend_name>[^\s]+)\s+(?P<backend_name>[^/]+)/(?P<server_name>[^\s]+)\s+(?P<queue_wait_time>[^/]+)/(?P<server_response_time>[^/]+)/(?P<session_duration>[^\s]+)\s+(?P<bytes_read>[^\s]+)\s+(?P<termination_state>[\w-]{2})\s+(?P<process_concurrent_connections>[^/]+)/(?P<frontend_concurrent_connections>[^/]+)/(?P<backend_concurrent_connections>[^/]+)/(?P<server_concurrent_connections>[^/]+)/(?P<retries>[^\s]+)\s+(?P<server_queue>[^/]+)/(?P<backend_queue>[\d]+)'
+    output: frontend_type_tcp_add
 
-  - id: add_label_tcp
+  - id: frontend_type_tcp_add
     type: add
-    field: $labels.log_type
-    value: 'haproxy.tcp'
+    field: frontend_type
+    value: tcp
+    output: add_info_severity
+
+  # Default severity to info
+  - id: add_info_severity
+    type: add
+    field: $record.severity
+    value: 'info'
+    output: error_severity_parser # Use error parser to parse our added info severity
   # {{ end }}
 
-  # Parse observiq format log message
   # {{ if eq $log_format "observiq" }}
-  - id: json_parser
+  # Route to correct parser
+  - id: message_router
+    type: router
+    default: message_move
+    routes:
+      - output: observiq_parser
+        expr: '$record.message != nil and $record.message matches "^{.*}$|^{.*}\\n$"'
+        labels:
+          log_type: 'haproxy.observiq'
+      - output: error_parser
+        expr: '$record.message != nil and $record.message matches "^\\s*\\[[^\\]]+\\]\\s*.*"'
+        labels:
+          log_type: 'haproxy.error'
+
+  # Parse observiq format log message
+  - id: observiq_parser
     type: json_parser
     if: '$record.message != nil and $record.message matches "^{.*}$|^{.*}\\n$"'
     parse_from: $record.message
-
-  - id: add_label_observiq
-    type: add
-    field: $labels.log_type
-    value: 'haproxy.observiq'
+    output: status_severity_parser
   # {{ end }}
 
+  # Group of parsers and restructure operators
   # Parse status if it exists
-  - type: severity_parser
+  - id: status_severity_parser
+    type: severity_parser
     if: '$record.status != nil'
     parse_from: $record.status
     preserve_to: $record.status
@@ -106,9 +142,123 @@ pipeline:
       notice: 3xx
       warning: 4xx
       error: 5xx
+    output: uri_parser
+
+  # Parse uri if it exists
+  - type: uri_parser
+    if: '$record.uri != nil'
+    parse_from: $record.uri
+    output: query_move
+
+  # Rename query to query_parameter
+  - id: query_move
+    type: move
+    if: '$record.query != nil'
+    from: $record.query
+    to: $record.query_parameter
+    output: protocol_parser
+
+  # Normalize protocol/version in JSON http_version to match regex http parser
+  - id: protocol_parser
+    type: regex_parser
+    if: '$record.http_version != nil'
+    parse_from: $record.http_version
+    regex: '(?P<protocol>[^/]*)/(?P<protocol_version>.*)'
+
+# frontend_ssl_version
+# frontend_ssl_ciphers
+# method
+# protocol
+# protocol_version
+# referer
+  # Promote fields to labels
+  - id: frontend_ssl_version_move
+    type: move
+    if: '$record.frontend_ssl_version != nil'
+    from: '$record.frontend_ssl_version'
+    to: '$labels["frontend_ssl_version"]'
+  - id: frontend_ssl_ciphers_move
+    type: move
+    if: '$record.frontend_ssl_ciphers != nil'
+    from: '$record.frontend_ssl_ciphers'
+    to: '$labels["frontend_ssl_ciphers"]'
+  - id: method_move
+    type: move
+    from: '$record.method'
+    to: '$labels["method"]'
+  - id: protocol_move
+    type: move
+    from: '$record.protocol'
+    to: '$labels["protocol"]'
+  - id: protocol_version_move
+    type: move
+    from: '$record.protocol_version'
+    to: '$labels["protocol_version"]'
+  - id: referer_move
+    type: move
+    if: '$record.referer != nil'
+    from: '$record.referer'
+    to: '$labels["referer"]'
+
+  # Promote fields to resources
+  - id: frontend_type_move
+    type: move
+    from: '$record.frontend_type'
+    to: '$resource["frontend_type"]'
+  - id: frontend_ip_move
+    type: move
+    from: '$record.frontend_ip'
+    to: '$resource["frontend_ip"]'
+  - id: path_move
+    type: move
+    if: '$record.move != nil'
+    from: '$record.path'
+    to: '$resource["path"]'
+  - id: query_parameters_move
+    type: move
+    if: '$record.query_parameters != nil'
+    from: '$record.query_parameters'
+    to: '$resource["query_parameters"]'
+  - id: frontend_name_move
+    type: move
+    from: '$record.frontend_name'
+    to: '$resource["frontend_name"]'
+  - id: backend_name_move
+    type: move
+    from: '$record.backend_name'
+    to: '$resource["backend_name"]'
+  - id: server_name_move
+    type: move
+    from: '$record.server_name'
+    to: '$resource["server_name"]'
+  - id: host_move
+    type: move
+    # if: $record.message != nil and $record.host == nil
+    from: '$record.host'
+    to: '$resource["host"]'
+    output: {{ .output }}
+  
+  # Parser error logs
+  # Severities: emerg alert crit err warning notice info debug
+  - id: error_parser
+    type: regex_parser
+    parse_from: $record.message
+    regex: ^\s*\[(?P<severity>[^\]]+)\]\s*(?P<message>.*)
+    output: error_severity_parser
+
+  - id: error_severity_parser
+    type: severity_parser
+    if: '$record.severity != nil'
+    parse_from: $record.severity
+    mapping:
+      critical: crit
+      emergency: emerg
+      error: err
+    output: {{ .output }}
 
   # If $record.message still exists and $record.host doesn't that means we were unable to parse and just need to promote to $record
-  - type: move
+  - id: message_move
+    type: move
     if: $record.message != nil and $record.host == nil
     from: $record.message
     to: $record

--- a/schemas/haproxy.yaml
+++ b/schemas/haproxy.yaml
@@ -1,0 +1,45 @@
+version: str()
+title: str()
+description: str()
+parameters: list(include('parameter'))
+pipeline: list(include('operator'))
+---
+parameter:
+  name: str()
+  label: str()
+  description: str()
+  type: str()
+  valid_values: list(required=False)
+
+operator:
+  id: str(required=False)
+  type: str()
+  include: list(required=False)
+  start_at: str(required=False)
+  labels: map(str(), required=False)
+  output: str(required=False) 
+  regex: str(required=False)
+  timestamp: map(include('timestamp_list'), str(), map(), required=False)
+  severity: map(include('severity_list'), str(), map(), required=False)
+
+timestamp_list:
+  parse_from: str()
+  layout: str()
+
+severity_list:
+  parse_from: str()
+  preset: str(required=False)
+  mapping: list(include('mapping_list'), str(), required=False)
+  preserve_to: str(required=False)
+  if: str(required=False)
+
+mapping_list:
+  info: str(required=False)
+  error: str(required=False)
+  warning: str(required=False)
+  critical: str(required=False)
+  debug: str(required=False)
+  trace: str(required=False)
+  alert: str(required=False)
+  emergency: str(required=False)
+  catastrophe: str(required=False)

--- a/test/configs/haproxy/invalid/file_log_path.yaml
+++ b/test/configs/haproxy/invalid/file_log_path.yaml
@@ -1,0 +1,5 @@
+pipeline:
+- type: haproxy
+  file_log_path: "/var/log/custom/path/haproxy/default.log"
+  start_at: beginning
+- type: stdout

--- a/test/configs/haproxy/invalid/log_format.yaml
+++ b/test/configs/haproxy/invalid/log_format.yaml
@@ -1,0 +1,6 @@
+pipeline:
+- type: haproxy
+  file_log_path: 
+    - "/var/log/custom/path/haproxy/default.log"
+  log_format: "invalid"
+- type: stdout

--- a/test/configs/haproxy/invalid/start_at.yaml
+++ b/test/configs/haproxy/invalid/start_at.yaml
@@ -1,0 +1,6 @@
+pipeline:
+- type: haproxy
+  file_log_path:
+    - "/var/log/custom/path/haproxy/default.log"
+  start_at: start
+- type: stdout

--- a/test/configs/haproxy/valid/full.yaml
+++ b/test/configs/haproxy/valid/full.yaml
@@ -1,0 +1,7 @@
+pipeline:
+- type: haproxy
+  file_log_path:
+    - "/var/log/custom/path/haproxy/default.log"
+  log_format: "http"
+  start_at: beginning
+- type: stdout

--- a/test/configs/haproxy/valid/full.yaml
+++ b/test/configs/haproxy/valid/full.yaml
@@ -2,6 +2,6 @@ pipeline:
 - type: haproxy
   file_log_path:
     - "/var/log/custom/path/haproxy/default.log"
-  log_format: "http"
+  log_format: "default"
   start_at: beginning
 - type: stdout

--- a/test/configs/haproxy/valid/minimal.yaml
+++ b/test/configs/haproxy/valid/minimal.yaml
@@ -1,0 +1,5 @@
+pipeline:
+- type: haproxy
+  file_log_path:
+    - "/var/log/custom/path/haproxy/default.log"
+- type: stdout


### PR DESCRIPTION
This will add new plugin to parse HAProxy from file. You can select between observiq, http, and tcp log formats. See below for references to the log formats.

### Default Log Format
https://www.haproxy.com/documentation/hapee/latest/onepage/#8.2.1

Example Output:
``` JSON
{
  "timestamp": "2021-09-19T15:49:00-04:00",
  "severity": 0,
  "labels": {
    "file_name": "json.log",
    "log_type": "haproxy.observiq",
    "plugin_id": "haproxy"
  },
  "record": {
    "host": "oiq-int-haproxy",
    "message": "Proxy apache started.",
    "pid": "15202",
    "process_name": "haproxy"
  }
}
```

### TCP Log Format
https://www.haproxy.com/documentation/hapee/latest/onepage/#8.2.2
```
log-format "%ci:%cp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq"
```
Example Output:
``` JSON
{
  "timestamp": "2021-09-19T15:49:00-04:00",
  "severity": 0,
  "labels": {
    "file_name": "tcp.log",
    "log_type": "haproxy.tcp",
    "plugin_id": "haproxy"
  },
  "record": {
    "accept_date": "06/Feb/2009:12:12:51.443",
    "backend_concurrent_connections": "0",
    "backend_name": "bck",
    "backend_queue": "0",
    "bytes_read": "212",
    "client_ip": "10.0.1.2",
    "client_port": "33313",
    "frontend_concurrent_connections": "0",
    "frontend_name": "fnt",
    "host": "oiq-int-haproxy",
    "pid": "14387",
    "process_concurrent_connections": "0",
    "process_name": "haproxy",
    "queue_wait_time": "0",
    "server_concurrent_connections": "0",
    "server_connection_retries": "3",
    "server_name": "srv1",
    "server_queue": "0",
    "server_response_time": "0",
    "session_duration": "5007",
    "termination_state": "--"
  }
}
```

### Http Log Format
https://www.haproxy.com/documentation/hapee/latest/onepage/#8.2.3

```
log-format "%ci:%cp [%tr] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Ta %ST %B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %hr %hs %{+Q}r"
```
Example Output:
``` JSON
{
  "timestamp": "2021-09-19T15:49:00-04:00",
  "severity": 60,
  "severity_text": "503",
  "labels": {
    "file_name": "http.log",
    "log_type": "haproxy.http",
    "plugin_id": "haproxy"
  },
  "record": {
    "accept_date": "16/Sep/2021:16:32:49.352",
    "backend_concurrent_connections": "0",
    "backend_name": "http",
    "backend_queue": "0",
    "bytes_read": "213",
    "captured_request_cookie": "-",
    "captured_response_cookie": "-",
    "client_ip": "127.0.0.1",
    "client_port": "40140",
    "client_request_active_time": "0",
    "client_request_send_time": "-1",
    "frontend_concurrent_connections": "1",
    "frontend_name": "http",
    "host": "oiq-int-haproxy",
    "method": "GET",
    "path": "/",
    "pid": "15165",
    "process_concurrent_connections": "1",
    "process_name": "haproxy",
    "protocol": "HTTP",
    "protocol_version": "1.1",
    "queue_wait_time": "-1",
    "server_concurrent_connections": "0",
    "server_connection_retries": "0",
    "server_name": "<NOSRV>",
    "server_queue": "0",
    "server_response_send_time": "-1",
    "server_response_time": "-1",
    "status": "503",
    "termination_state": "SC--"
  }
}
```

### Observiq Log Format

Will update with log-format

Example Output:
``` JSON
{
  "timestamp": "2021-09-18T15:39:01-04:00",
  "severity": 50,
  "severity_text": "404",
  "labels": {
    "file_name": "json.log",
    "log_type": "haproxy.observiq",
    "plugin_id": "haproxy"
  },
  "record": {
    "frontend_addr": "10.33.104.161",
    "frontend_port": 8080,
    "frontend_ssl_ciphers": "-",
    "frontend_ssl_version": "-",
    "haproxy_backend_concurrent_connections": 0,
    "haproxy_backend_name": "apache",
    "haproxy_backend_queue": 0,
    "haproxy_client_request_send_time": 0,
    "haproxy_frontend_concurrent_connections": 1,
    "haproxy_frontend_name": "http",
    "haproxy_frontend_type": "http",
    "haproxy_process_concurrent_connections": 1,
    "haproxy_queue_wait_time": 0,
    "haproxy_server_concurrent_connections": 1,
    "haproxy_server_connection_retries": 0,
    "haproxy_server_name": "apache",
    "haproxy_server_queue": 0,
    "haproxy_server_response_send_time": 0,
    "haproxy_server_wait_time": 0,
    "host": "10.33.104.161:8080",
    "pid": 15705,
    "process_name": "haproxy",
    "referer": "-",
    "remote_addr": "10.33.104.161",
    "remote_port": 55498,
    "request_http_version": "HTTP/1.1",
    "request_method": "GET",
    "request_size": 136,
    "request_termination_state": "----",
    "request_uri": "/v1/api/app?user=dev",
    "response_size": 438,
    "response_time": 1,
    "session_duration": 1,
    "status": 404
  }
}
```