### PR TITLE
Add more checks to reduce errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.78] - Unreleased
+## [0.0.79] - unrelease
 
 ### Added
 
 - Added haproxy plugin ([334](https://github.com/observIQ/stanza-plugins/pull/334))
+
+### Fixed
+
+- Updated ubiquiti plugin ([337](https://github.com/observIQ/stanza-plugins/pull/337))
+  - Moved catchall from default to a route with pattern matching and set default to output in router.
+  - Added if checks to determine if fields exist before doing operation `promote_name`, `promote_device`, and `severity_parser`. This will stop errors in log file if fields do not exist.
+
+## [0.0.78] - 2021-09-15
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated ubiquiti plugin ([337](https://github.com/observIQ/stanza-plugins/pull/337))
+  - Updated `ac_lite_ap_parser` expression check to be more inline with expected format.
   - Moved catchall from default to a route with pattern matching and set default to output in router.
   - Added if checks to determine if fields exist before doing operation `promote_name`, `promote_device`, and `severity_parser`. This will stop errors in log file if fields do not exist.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.80] 2021-09-23
+
+### Fixed
+- HAProxy: Promote frontend_port as a resources ([PR338](https://github.com/observIQ/stanza-plugins/pull/338))
+- Updated ubiquiti plugin ([337](https://github.com/observIQ/stanza-plugins/pull/337))
+  - Updated `ac_lite_ap_parser` expression check to be more inline with expected format.
+  - Moved catchall from default to a route with pattern matching and set default to output in router.
+  - Added if checks to determine if fields exist before doing operation `promote_name`, `promote_device`, and `severity_parser`. This will stop errors in log file if fields do not exist.
+
 ## [0.0.79] - 2021-09-22
 
 ### Added
@@ -18,15 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Resolved issue where default listener path is not correct
 - Oracle Database: ([PR 331](https://github.com/observIQ/stanza-plugins/pull/331))
   - Resolves issue where regex fails to parse audit file dbid
-
-## [0.0.78] - 2021-09-16
-
-### Fixed
-
-- Updated ubiquiti plugin ([337](https://github.com/observIQ/stanza-plugins/pull/337))
-  - Updated `ac_lite_ap_parser` expression check to be more inline with expected format.
-  - Moved catchall from default to a route with pattern matching and set default to output in router.
-  - Added if checks to determine if fields exist before doing operation `promote_name`, `promote_device`, and `severity_parser`. This will stop errors in log file if fields do not exist.
 
 ## [0.0.78] - 2021-09-15
 

--- a/plugins/ubiquiti.yaml
+++ b/plugins/ubiquiti.yaml
@@ -49,12 +49,14 @@ pipeline:
   
   - id: device_router
     type: router
-    default: catch_all_parser
+    default: {{.output}}
     routes:
-      - expr: '$record matches "^<\\d+>\\w{3}\\s*\\d{1,2}\\s*\\d{2}:\\d{2}:\\d{2}"'
+      - expr: '$record matches "^<\\d+>\\w{3}\\s*\\d{1,2}\\s*\\d{2}:\\d{2}:\\d{2}\\s*[^,]*,[^:]*:(\\s*)?[^:]*(\\s*)?:[\\s\\S]*"'
         output: ac_lite_ap_parser
       - expr: '$record matches "^<[^>]+>[^ ]*\\s*[^,]*,[^,]*,[^:]*:(\\s*)?[^:]*:(\\s*)?[\\s\\S]*"'
         output: flex_mini_parser
+      - expr: '$record matches "^<\\d+>[\\s\\S]*"'
+        output: catch_all_parser
 
   # This pattern is known to match AC Lite access points
   - id: ac_lite_ap_parser
@@ -72,9 +74,11 @@ pipeline:
     type: regex_parser
     regex: '^<(?P<priority>[^>]+)>(?P<name>[^ ]*)\s*(?P<device>[^,]*),(?P<mac_address>[^,]*),(?P<firmware_version>[^:]*):(\s*)?(?P<service>[^:]*):(\s*)?(?P<message>[\s\S]*)'
     output: promote_name
+
   # promote name field to resource. name is specific to flex_mini_parser.
   - id: promote_name
     type: move
+    if: '$record.name != nil'
     from: $record.name
     to: '$resource["name"]'
     output: promote_device
@@ -82,6 +86,7 @@ pipeline:
   # promote device field to resource
   - id: promote_device
     type: move
+    if: '$record.device != nil'
     from: $record.device
     to: '$resource["device"]'
     output: severity_parser
@@ -94,6 +99,7 @@ pipeline:
     output: severity_parser
 
   - type: severity_parser
+    if: '$record.priority != nil'
     parse_from: $record.priority
     preserve_to: $record.priority
     mapping:


### PR DESCRIPTION
This will help reduce errors when log input doesn't match expected format.  
  - Moved catchall from default to a route with pattern matching and set default to output in router.
  - Added if checks to determine if fields exist before doing operation `promote_name`, `promote_device`, and `severity_parser`. 