### PR TITLE
move frontend port to resources

### DIFF
--- a/plugins/haproxy.yaml
+++ b/plugins/haproxy.yaml
@@ -208,6 +208,11 @@ pipeline:
     if: '$record.frontend_ip != nil'
     from: '$record.frontend_ip'
     to: '$resource["frontend_ip"]'
+  - id: frontend_port_move
+    type: move
+    if: '$record.frontend_port != nil'
+    from: '$record.frontend_port'
+    to: '$resource["frontend_port"]'
   - id: path_move
     type: move
     if: '$record.move != nil'


### PR DESCRIPTION
Frontend port should be a resource. Previously, the frontend port field was a number, and could not be set as a resource because resources are a map of strings `map[string]string`. I have updated the logging configuration to output a string value for frontend port to overcome this limitation.

My test env has frontend_port represented properly:

<img width="450" alt="Screen Shot 2021-09-23 at 1 16 03 PM" src="https://user-images.githubusercontent.com/23043836/134553721-30bc4522-7008-438d-b79a-58d47b895c95.png">
 