### PR TITLE
parse dst, src and rename proto to protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `sonicwall`: Parse `src` and `dst` fields into ip, port, and interface fields: ([PR355](https://github.com/observIQ/stanza-plugins/pull/355))
 - `cisco_catalyst`: Renamed `facility` to `facility_text` ([PR354](https://github.com/observIQ/stanza-plugins/pull/354))
  
 ## [0.0.85] 2021-10-04

--- a/plugins/sonicwall.yaml
+++ b/plugins/sonicwall.yaml
@@ -103,14 +103,30 @@ pipeline:
       layout_type: gotime
       layout: '2006-01-02 15:04:05'
       location: {{$location}}
-    output: msg_move
+
+  - id: proto_move
+    type: move
+    if: $record.proto != nil
+    from: $record.proto
+    to: $record.protocol
 
   - id: msg_move
     type: move
     if: $record.msg != nil
     from: $record.msg
     to: $record.message
-    output: pri_severity_parser
+
+  - id: parse_dst
+    type: regex_parser
+    if: $record.dst != nil
+    parse_from: $record.dst
+    regex: '^(?P<dst_ip>.*):(?P<dst_port>.*):(?P<dst_interface>.*)'
+
+  - id: parse_src
+    type: regex_parser
+    if: $record.src != nil
+    parse_from: $record.src
+    regex: '^(?P<src_ip>.*):(?P<src_port>.*):(?P<src_interface>.*)'
 
   # If priority field doesn't exist and pri field does, use pri field.
   - id: pri_severity_parser


### PR DESCRIPTION
- parse dst into ip, port, interface
- parse src into ip, port, interface
- rename proto to protocol
```json
{
  "timestamp": "2021-09-13T18:16:13Z",
  "severity": 30,
  "severity_text": "134",
  "labels": {
    "log_type": "sonicwall",
    "net.host.ip": "::",
    "net.host.port": "5555",
    "net.peer.ip": "::1",
    "net.peer.port": "36748",
    "net.transport": "IP.UDP",
    "plugin_id": "sonicwall"
  },
  "record": {
    "c": "262144",
    "dst_interface": "X1",
    "dst_ip": "142.250.64.68",
    "dst_port": "443",
    "fw": "142.166.177.10",
    "gcat": "6",
    "id": "LVM_Sonicwall",
    "m": "98",
    "message": "Connection Opened",
    "n": "53798",
    "natDst": "142.250.64.68:443",
    "natSrc": "142.166.177.10:51879",
    "pri": "6",
    "priority": "134",
    "protocol": "tcp/https",
    "sent": "60",
    "sn": "18B1693B2C90",
    "src_interface": "X0",
    "src_ip": "192.168.11.53",
    "src_port": "36510"
  }
}
```