### PR TITLE
Revert cisco_meraki kvp change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.87] Unreleased
+
+### Changed
+
+- `cisco_meraki`: Removed `key_value_parser` due to some log entries not following needed pattern ([PR357](https://github.com/observIQ/stanza-plugins/pull/357))
+
 ## [0.0.86] 2021-10-05
 
 ### Changed

--- a/plugins/cisco_meraki.yaml
+++ b/plugins/cisco_meraki.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.8
+version: 0.0.9
 title: Cisco Meraki
 description: Log parser for Cisco Meraki
 min_stanza_version: 1.2.7

--- a/plugins/cisco_meraki.yaml
+++ b/plugins/cisco_meraki.yaml
@@ -72,11 +72,36 @@ pipeline:
       notice: [5,13,21,29,37,45,53,61,69,77,85,93,101,109,117,125,133,141,149,157,165,173,181,189]
       info: [6,14,22,30,38,46,54,62,70,78,86,94,102,110,118,126,134,142,150,158,166,174,182,190]
       debug: [7,15,23,31,39,47,55,63,71,79,87,95,103,111,119,127,135,143,151,159,167,175,183,191]
-    output: key_value_parser
+    output: message_router
 
-  - type: key_value_parser
-    if: '$record.message != nil'
-    parse_from: message
+  # Route messages to different regex's for further parsing. If a regex match is not found then don't parse message.
+  - id: message_router
+    type: router
+    default: {{.output}}
+    routes:
+      - expr: '$record.message matches "^src=.*\\s*dst=.*\\s*protocol=.*\\s*sport=.*\\s*dport=.*\\s*translated_src_ip=.*\\s*translated_port=.*\\s*"'
+        output: message_1_parser
+      - expr: '$record.message matches "^src=.*\\s*dst=.*\\s*mac=.*\\s*protocol=.*\\s*sport=.*\\s*dport=.*"'
+        output: message_2_parser
+      - expr: '$record.message matches "^src=.*\\s*dst=.*\\s*mac=.*\\s*user=.*\\s*"'
+        output: message_3_parser
+
+  - id: message_1_parser
+    type: regex_parser
+    parse_from: $record.message
+    regex: '^src=(?P<src>[^\s]*)\s*dst=(?P<dst>[^\s]*)\s*protocol=(?P<protocol>[^\s]*)\s*sport=(?P<sport>[^\s]*)\s*dport=(?P<dport>[^\s]*)\s*translated_src_ip=(?P<translated_src_ip>[^\s]*)\s*translated_port=(?P<translated_port>[^\s]*)\s*(?P<message>[\s\S]*)'
+    output: {{.output}}
+
+  - id: message_2_parser
+    type: regex_parser
+    parse_from: $record.message
+    regex: '^src=(?P<src>[^\s]*)\s*dst=(?P<dst>[^\s]*)\s*mac=(?P<mac>[^\s]*)\s*protocol=(?P<protocol>[^\s]*)\s*sport=(?P<sport>[^\s]*)\s*dport=(?P<dport>[^\s]*)\s*(?P<message>[\s\S]*)'
+    output: {{.output}}
+
+  - id: message_3_parser
+    type: regex_parser
+    parse_from: $record.message
+    regex: '^src=(?P<src>[^\s]*)\s*dst=(?P<dst>[^\s]*)\s*mac=(?P<mac>[^\s]*)\s*user=(?P<user>[^\s]*)\s*(?P<message>[\s\S]*)'
     output: {{.output}}
 
   - id: catch_all_parser


### PR DESCRIPTION
This reverts change that switch to using `key_value_parser`.  This will use original regex parsing methods.