### PR TITLE
Fix parsing error when log messages start with syslog priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.87] Unreleased
+
+### Changed
+
+- `cisco_catalyst`: Fix parsing error when log messages start with syslog priority ([PR358](https://github.com/observIQ/stanza-plugins/pull/358))
+
 ## [0.0.86] 2021-10-05
 
 ### Changed

--- a/plugins/cisco_catalyst.yaml
+++ b/plugins/cisco_catalyst.yaml
@@ -36,9 +36,28 @@ pipeline:
       log_type: 'cisco_catalyst'
       plugin_id: {{ .id }}
     add_labels: {{$add_labels}}
+    write_to: message
 
-  - type: regex_parser
+  - id: regex_router
+    type: router
+    default: {{.output}}
+    routes:
+      - expr: '$record.message matches "^<[^>]+>"'
+        output: syslog_beginning_parser
+      - expr: '$record.message matches "^[\\d]+:\\s+\\w+\\s+\\d+\\s+\\d+:\\d+:\\d+\\s+\\w+:"'
+        output: catalyst_parser
+
+  - id: syslog_beginning_parser
+    if: '$record.message matches "^<[\\d]+>"'
+    type: regex_parser
+    parse_from: message
+    regex: '^<(?P<priority>[^>]+)>(\s*)?(?P<message>[\s\S]*)'
+    output: catalyst_parser
+
+  - id: catalyst_parser
+    type: regex_parser
     regex: '^(?P<sequence_number>\d+):\s+(?P<timestamp>\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\w{3}):\s+%(?P<facility_text>[^-]+)-(?P<severity>\d+)-(?P<mnemonic>[^:]+):\s*(?P<message>.*)'
+    parse_from: message
     timestamp:
       parse_from: $record.timestamp
       layout_type: gotime

--- a/plugins/cisco_catalyst.yaml
+++ b/plugins/cisco_catalyst.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 title: Cisco Catalyst
 description: Log parser for Cisco Catalyst
 supported_platforms:


### PR DESCRIPTION
This will parsing error when messages starts with a syslog priority.

### Example Log that causes error
```
<188>2186: Oct 6 15:15:34 EDT: %SW_MATM-4-MACFLAP_NOTIF: Host 7634.9f4b.b08c in vlan 20 is flapping between port Gi1/0/25 and port Gi1/0/1
```

### Example Output after fixes
``` json
{
  "timestamp": "2021-10-06T14:15:34-04:00",
  "severity": 50,
  "severity_text": "4",
  "labels": {
    "log_type": "cisco_catalyst",
    "net.host.ip": "::",
    "net.host.port": "514",
    "net.peer.ip": "127.0.0.1",
    "net.peer.port": "58740",
    "net.transport": "IP.UDP",
    "plugin_id": "cisco_catalyst"
  },
  "record": {
    "facility_text": "SW_MATM",
    "message": "Host 9534.9t4t.08t in vlan 20 is flapping between port Gi1/0/25 and port Gi1/0/1",
    "mnemonic": "MACFLAP_NOTIF",
    "priority": "188",
    "sequence_number": "2186"
  }
}
```