### PR TITLE
rebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.87] Unreleased
+
+### Changed
+
+- `cisco_meraki`: Removed `key_value_parser` due to some log entries not following needed pattern ([PR357](https://github.com/observIQ/stanza-plugins/pull/357))
+- `cisco_catalyst`: Fix parsing error when log messages start with syslog priority ([PR358](https://github.com/observIQ/stanza-plugins/pull/358))
+
 ## [0.0.86] 2021-10-05
 
 ### Changed

--- a/plugins/cisco_catalyst.yaml
+++ b/plugins/cisco_catalyst.yaml
@@ -36,9 +36,28 @@ pipeline:
       log_type: 'cisco_catalyst'
       plugin_id: {{ .id }}
     add_attributes: {{$add_labels}}
+    write_to: message
 
-  - type: regex_parser
+  - id: regex_router
+    type: router
+    default: {{.output}}
+    routes:
+      - expr: '$body.message matches "^<[^>]+>"'
+        output: syslog_beginning_parser
+      - expr: '$body.message matches "^[\\d]+:\\s+\\w+\\s+\\d+\\s+\\d+:\\d+:\\d+\\s+\\w+:"'
+        output: catalyst_parser
+
+  - id: syslog_beginning_parser
+    if: '$body.message matches "^<[\\d]+>"'
+    type: regex_parser
+    parse_from: message
+    regex: '^<(?P<priority>[^>]+)>(\s*)?(?P<message>[\s\S]*)'
+    output: catalyst_parser
+
+  - id: catalyst_parser
+    type: regex_parser
     regex: '^(?P<sequence_number>\d+):\s+(?P<timestamp>\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\w{3}):\s+%(?P<facility_text>[^-]+)-(?P<severity>\d+)-(?P<mnemonic>[^:]+):\s*(?P<message>.*)'
+    parse_from: message
     timestamp:
       parse_from: $body.timestamp
       layout_type: gotime

--- a/plugins/cisco_meraki.yaml
+++ b/plugins/cisco_meraki.yaml
@@ -59,7 +59,7 @@ pipeline:
       layout: 's.ns'
     output: severity_parser
 
-  # Severity Parser using piority field to get the severity
+  # Severity Parser using priority field to get the severity
   - type: severity_parser
     if: '$body.priority != nil'
     parse_from: $body.priority
@@ -72,12 +72,36 @@ pipeline:
       info2: [5,13,21,29,37,45,53,61,69,77,85,93,101,109,117,125,133,141,149,157,165,173,181,189]
       info: [6,14,22,30,38,46,54,62,70,78,86,94,102,110,118,126,134,142,150,158,166,174,182,190]
       debug: [7,15,23,31,39,47,55,63,71,79,87,95,103,111,119,127,135,143,151,159,167,175,183,191]
-    output: key_value_parser
+    output: message_router
 
-  - type: key_value_parser
-    if: '$body.message != nil'
-    parse_from: message
+  # Route messages to different regex's for further parsing. If a regex match is not found then don't parse message.
+  - id: message_router
+    type: router
+    default: {{.output}}
+    routes:
+      - expr: '$body.message matches "^src=.*\\s*dst=.*\\s*protocol=.*\\s*sport=.*\\s*dport=.*\\s*translated_src_ip=.*\\s*translated_port=.*\\s*"'
+        output: message_1_parser
+      - expr: '$body.message matches "^src=.*\\s*dst=.*\\s*mac=.*\\s*protocol=.*\\s*sport=.*\\s*dport=.*"'
+        output: message_2_parser
+      - expr: '$body.message matches "^src=.*\\s*dst=.*\\s*mac=.*\\s*user=.*\\s*"'
+        output: message_3_parser
+
+  - id: message_1_parser
+    type: regex_parser
+    parse_from: $body.message
+    regex: '^src=(?P<src>[^\s]*)\s*dst=(?P<dst>[^\s]*)\s*protocol=(?P<protocol>[^\s]*)\s*sport=(?P<sport>[^\s]*)\s*dport=(?P<dport>[^\s]*)\s*translated_src_ip=(?P<translated_src_ip>[^\s]*)\s*translated_port=(?P<translated_port>[^\s]*)\s*(?P<message>[\s\S]*)'
     output: {{.output}}
+
+  - id: message_2_parser
+    type: regex_parser
+    parse_from: $body.message
+    regex: '^src=(?P<src>[^\s]*)\s*dst=(?P<dst>[^\s]*)\s*mac=(?P<mac>[^\s]*)\s*protocol=(?P<protocol>[^\s]*)\s*sport=(?P<sport>[^\s]*)\s*dport=(?P<dport>[^\s]*)\s*(?P<message>[\s\S]*)'
+    output: {{.output}}
+
+  - id: message_3_parser
+    type: regex_parser
+    parse_from: $body.message
+    regex: '^src=(?P<src>[^\s]*)\s*dst=(?P<dst>[^\s]*)\s*mac=(?P<mac>[^\s]*)\s*user=(?P<user>[^\s]*)\s*(?P<message>[\s\S]*)'
 
   - id: catch_all_parser
     if: '$body matches "^<[\\d]+>"'


### PR DESCRIPTION
- `cisco_meraki`: Removed `key_value_parser` due to some log entries not following needed pattern ([PR357](https://github.com/observIQ/stanza-plugins/pull/357))
- `cisco_catalyst`: Fix parsing error when log messages start with syslog priority ([PR358](https://github.com/observIQ/stanza-plugins/pull/358))