### PR TITLE
Update plugins using tcp_input to use otel tls config

### DIFF
--- a/plugins/vmware_esxi.yaml
+++ b/plugins/vmware_esxi.yaml
@@ -63,10 +63,11 @@ pipeline:
       log_type: vmware_esxi
       plugin_id: {{ .id }}
     add_attributes: true
+    # {{ if $enable_tls }}
     tls:
-      enable: {{ $enable_tls }}
-      certificate: {{ $certificate_file }}
-      private_key: {{ $private_key_file }}
+      cert_file: {{ $certificate_file }}
+      key_file: {{ $private_key_file }}
+    # {{ end }}
     output: timestamp_router
   - id: timestamp_router
     type: router

--- a/plugins/vmware_vcenter.yaml
+++ b/plugins/vmware_vcenter.yaml
@@ -72,10 +72,11 @@ pipeline:
       log_type: vmware_vcenter
       plugin_id: {{ .id }}
     add_attributes: true
+    # {{ if $enable_tls }}
     tls:
-      enable: {{ $enable_tls }}
-      certificate: {{ $certificate_file }}
-      private_key: {{ $private_key_file }}
+      cert_file: {{ $certificate_file }}
+      key_file: {{ $private_key_file }}
+    # {{ end }}
     output: prefix_router
 
   # vcenter will (sometimes) prepend an id to the messages, check


### PR DESCRIPTION
The tcp_input operator in opentelemetry-log-collection uses the standard [TLSServerSetting](https://pkg.go.dev/go.opentelemetry.io/collector@v0.35.0/config/configtls#TLSServerSetting) struct instead of what we're currently using in Stanza. This changes the structure of the settings.

This fixes the VMware vCenter and VMware ESXi plugins, which previously had the following error when configured:
```
Brandons-MacBook-Pro.local encountered an error: cannot setup pipelines: cannot start receivers: start stanza: failed to listen on interface: failed to configure tls listener: tls: neither Certificates, GetCertificate, nor GetConfigForClient set in Config
```