### PR TITLE
Update Rsyslog plugin to allow file input option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `cisco_meraki`: Removed `key_value_parser` due to some log entries not following needed pattern ([PR357](https://github.com/observIQ/stanza-plugins/pull/357))
 - `cisco_catalyst`: Fix parsing error when log messages start with syslog priority ([PR358](https://github.com/observIQ/stanza-plugins/pull/358))
+- `rsyslog`: Add file `source` option for log input ([PR362](https://github.com/observIQ/stanza-plugins/pull/362))
 
 ## [0.0.86] 2021-10-05
 

--- a/plugins/rsyslog.yaml
+++ b/plugins/rsyslog.yaml
@@ -1,21 +1,41 @@
 # Plugin Info
-version: 0.0.3
+version: 0.0.4
 title: Rsyslog
 description: Log parser for Rsyslog
 parameters:
+  - name: source
+    label: Log source
+    description: Use this field to specify where your logs are coming from. When choosing the 'file' option, the agent reads in logs from the log paths specified below. When choosing the 'tcp' or 'udp' options, the agent will listen on specified port.
+    type: enum
+    valid_values:
+      - file
+      - udp
+      - tcp
+    default: udp
   - name: listen_port
     label: Listen Port
     description: A port which the agent will listen for syslog messages
     type: int
     default: 514
-  - name: connection_type
-    label: Connection Type
-    description: The type of Rsyslog connection (`udp` or `tcp`)
+  - name: rsyslog_log_path
+    label: Rsyslog Log Path
+    description: Path to Rsyslog log file
+    type: string
+    default: " "
+    relevant_if:
+      source:
+        equals: file
+  - name: start_at
+    label: Start At
+    description: Start reading file from 'beginning' or 'end'
     type: enum
     valid_values:
-      - udp
-      - tcp
-    default: udp
+      - beginning
+      - end
+    default: end
+    relevant_if:
+      source:
+        equals: file
   - name: protocol
     label: Protocol
     description: The protocol of received Rsyslog messages (`rfc3164` or `rfc5424`)
@@ -24,6 +44,11 @@ parameters:
       - rfc3164 (BSD)
       - rfc5424 (IETF)
     default: rfc5424 (IETF)
+    relevant_if:
+      source:
+        equals: tcp
+      source:
+        equals: udp
   - name: location
     label: Geographic Location
     description: The geographic location (timezone) to use when parsing the timestamp (Rsyslog RFC 3164 only)
@@ -40,6 +65,11 @@ parameters:
     type: string
     default: "0.0.0.0"
     advanced_config: true
+    relevant_if:
+      source:
+        equals: tcp
+      source:
+        equals: udp
   - name: listen_address
     label: Listen Address
     description: Parameter Deprecated Use `listen_ip` and `listen_port` instead.
@@ -49,17 +79,31 @@ parameters:
     hidden: true
 
 # Set Defaults
+# {{$source := default "udp" .source}}
+# {{$rsyslog_log_path := default "" .rsyslog_log_path}}
+# {{$start_at := default "end" .start_at}}
 # {{$listen_address := default "" .listen_address}}
 # {{$length := len $listen_address}}
 # {{$listen_ip := default "0.0.0.0" .listen_ip}}
 # {{$listen_port := default 514 .listen_port}}
-# {{$connection_type := default "udp" .connection_type}}
 # {{$protocol := default "rfc5424 (IETF)" .protocol}}
 # {{$location := default "UTC" .location}}
 
 # Pipeline Template
 pipeline:
-# {{ if eq $connection_type "udp" }}
+# {{ if eq $source "file" }}
+  - id: file_reader
+    type: file_input
+    include:
+      - '{{ $rsyslog_log_path }}'
+    start_at: '{{ $start_at }}'
+    labels:
+      log_type: 'rsyslog'
+      plugin_id: '{{ .id }}'
+    output: regex_parser
+# {{ end }}
+
+# {{ if eq $source "udp" }}
   - id: rsyslog_udp_input
     type: udp_input
     listen_address: '{{ if eq $length 0 }}{{ $listen_ip }}:{{ $listen_port }}{{ else }}{{ $listen_address }}{{ end }}'
@@ -70,7 +114,7 @@ pipeline:
     output: rsyslog_parser
 # {{ end }}
 
-# {{ if eq $connection_type "tcp" }}
+# {{ if eq $source "tcp" }}
   - id: rsyslog_tcp_input
     type: tcp_input
     listen_address: '{{ if eq $length 0 }}{{ $listen_ip }}:{{ $listen_port }}{{ else }}{{ $listen_address }}{{ end }}'
@@ -87,4 +131,12 @@ pipeline:
 # {{ if eq $protocol "rfc3164 (BSD)" }}
     location: {{$location}}
 # {{ end }}
+    output: {{ .output }}
+
+  - type: regex_parser
+    regex: '^(?P<timestamp>\w{3}\s+\d{2}\s+\d{2}:\d{2}:\d{2})\s+(?P<host>[^\s]+)\s+(?P<process_name>[^\[]+)(\[(?P<pid>[^\]]+)\])?:(\s)?(?P<message>.*)'
+    timestamp:
+      parse_from: timestamp
+      layout_type: gotime
+      layout: 'Jan 02 15:04:05'
     output: {{ .output }}


### PR DESCRIPTION
Adds option to read rsyslog input with files.

Example Output:
``` json
{
  "timestamp": "2021-10-10T16:26:06-04:00",
  "severity": 0,
  "labels": {
    "file_name": "file.log",
    "log_type": "rsyslog",
    "plugin_id": "rsyslog"
  },
  "record": {
    "host": "oiq-int-apache",
    "message": "Started Session 12157 of user root.",
    "pid": "",
    "process_name": "systemd"
  }
}
```