### PR TITLE
Default plugins to use utf-8 rather than nop

### DIFF
--- a/plugins/asterisk.yaml
+++ b/plugins/asterisk.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.2
+version: 0.0.3
 title: Asterisk
 description: Log Parser for Asterisk
 min_stanza_version: 1.2.3
@@ -20,13 +20,12 @@ parameters:
     description: Specify the encoding of the file(s) being read. In most cases, you can leave the default option selected.
     type: enum
     valid_values:
-      - nop
       - utf-8
       - utf-16le
       - utf-16be
       - ascii
       - big5
-    default: nop
+    default: utf-8
     advanced_config: true
   - name: timestamp_format
     label: Timestamp Format
@@ -47,7 +46,7 @@ parameters:
     default: end
 # Set Defaults
 # {{$timestamp_format := default "ISO 8601" .timestamp_format}}
-# {{$encoding := default "nop" .encoding}}
+# {{$encoding := default "utf-8" .encoding}}
 # {{$start_at := default "end" .start_at}}
 
 # Pipeline Template

--- a/plugins/csv.yaml
+++ b/plugins/csv.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: CSV
 description: File Input CSV Parser
 min_stanza_version: 0.13.12
@@ -24,13 +24,12 @@ parameters:
     description: Specify the encoding of the file(s) being read. In most cases, you can leave the default option selected.
     type: enum
     valid_values:
-      - nop
       - utf-8
       - utf-16le
       - utf-16be
       - ascii
       - big5
-    default: nop
+    default: utf-8
   - name: log_type
     label: Type
     description: Adds the specified 'Type' as a label to each log message.
@@ -46,7 +45,7 @@ parameters:
     default: end
 # Set Defaults
 # {{$header := .header}}
-# {{$encoding := default "nop" .encoding}}
+# {{$encoding := default "utf-8" .encoding}}
 # {{$log_type := default "csv" .log_type}}
 # {{$start_at := default "end" .start_at}}
 

--- a/plugins/file.yaml
+++ b/plugins/file.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 0.0.2
 title: File
 description: File Input Parser
 min_stanza_version: 0.13.12
@@ -33,13 +33,12 @@ parameters:
     description: Specify the encoding of the file(s) being read. In most cases, you can leave the default option selected.
     type: enum
     valid_values:
-      - nop
       - utf-8
       - utf-16le
       - utf-16be
       - ascii
       - big5
-    default: nop
+    default: utf-8
   - name: log_type
     label: Type
     description: Adds the specified 'Type' as a label to each log message.
@@ -56,7 +55,7 @@ parameters:
 # Set Defaults
 # {{$enable_multiline := default false .enable_multiline}}
 # {{$multiline_line_start_pattern := default "" .multiline_line_start_pattern}}
-# {{$encoding := default "nop" .encoding}}
+# {{$encoding := default "utf-8" .encoding}}
 # {{$log_type := default "file" .log_type}}
 # {{$start_at := default "end" .start_at}}
 

--- a/plugins/nginx.yaml
+++ b/plugins/nginx.yaml
@@ -1,4 +1,4 @@
-version: 0.0.13
+version: 0.0.14
 title: Nginx
 description: Log parser for Nginx
 min_stanza_version: 0.13.12
@@ -92,13 +92,12 @@ parameters:
     description: Specify the encoding of the file(s) being read. In most cases, you can leave the default option selected.
     type: enum
     valid_values:
-      - nop
       - utf-8
       - utf-16le
       - utf-16be
       - ascii
       - big5
-    default: nop
+    default: utf-8
 
 # Set Defaults
 # {{$source := default "file" .source}}
@@ -111,7 +110,7 @@ parameters:
 # {{$enable_error_log := default true .enable_error_log}}
 # {{$error_log_path := default "/var/log/nginx/error.log*" .error_log_path}}
 # {{$start_at := default "end" .start_at}}
-# {{$encoding := default "nop" .encoding}}
+# {{$encoding := default "utf-8" .encoding}}
 
 # Pipeline Template
 pipeline:

--- a/plugins/tail.yaml
+++ b/plugins/tail.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.3
+version: 0.0.4
 title: Tail
 description: File Input Parser
 min_stanza_version: 0.13.12
@@ -33,13 +33,12 @@ parameters:
     description: The encoding of the log file.
     type: enum
     valid_values:
-      - nop
       - utf-8
       - utf-16le
       - utf-16be
       - ascii
       - big5
-    default: nop
+    default: utf-8
   - name: parse_format
     label: Format
     description: The log format to parse.
@@ -64,7 +63,7 @@ parameters:
 # Set Defaults
 # {{$enable_multiline := default false .enable_multiline}}
 # {{$multiline_line_start_pattern := default "" .multiline_line_start_pattern}}
-# {{$encoding := default "nop" .encoding}}
+# {{$encoding := default "utf-8" .encoding}}
 # {{$parse_format := default "none" .parse_format}}
 # {{$log_type := default "tail" .log_type}}
 # {{$start_at := default "end" .start_at}}

--- a/plugins/w3c.yaml
+++ b/plugins/w3c.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.2
+version: 0.0.3
 title: W3C
 description: File Input W3C Parser
 min_stanza_version: 1.2.0
@@ -19,13 +19,12 @@ parameters:
     description: Specify the encoding of the file(s) being read. In most cases, you can leave the default option selected.
     type: enum
     valid_values:
-      - nop
       - utf-8
       - utf-16le
       - utf-16be
       - ascii
       - big5
-    default: nop
+    default: utf-8
   - name: log_type
     label: Type
     description: Adds the specified 'Type' as a label to each log message.
@@ -89,7 +88,7 @@ parameters:
     type: string
     default: "\t"
 # Set Defaults
-# {{$encoding := default "nop" .encoding}}
+# {{$encoding := default "utf-8" .encoding}}
 # {{$log_type := default "w3c" .log_type}}
 # {{$start_at := default "end" .start_at}}
 # {{$delete_after_read := default false .delete_after_read}}


### PR DESCRIPTION
Planning on removing support for nop encoded `file_input` because plugin ingestors like stanza and opentelemetry-log-collection plan to only support string encodings. 


