### PR TITLE
use enum for tls min version. fix friendly name

### DIFF
--- a/plugins/http.yaml
+++ b/plugins/http.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.1
+version: 1.0.1
 title: HTTP
 description: HTTP Input
 min_stanza_version: 1.2.10


### PR DESCRIPTION
- Fix http input label
- Use enum instead of string for min tls version, we know the valid values so we should enforce them