### PR TITLE
Fix timestamp parser error in cisco_catalyst plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `haproxy`: Fixed typo with field name `query_parameter` ([PR368](https://github.com/observIQ/stanza-plugins/pull/368))
+- `cisco_catalyst`: Fix timestamp parse issue with `*` in front of timestamp. ([PR375](https://github.com/observIQ/stanza-plugins/pull/375))
 
 ## [0.0.87] 2021-10-11
 

--- a/plugins/cisco_catalyst.yaml
+++ b/plugins/cisco_catalyst.yaml
@@ -1,4 +1,4 @@
-version: 0.0.2
+version: 0.0.3
 title: Cisco Catalyst
 description: Log parser for Cisco Catalyst
 supported_platforms:
@@ -44,7 +44,7 @@ pipeline:
     routes:
       - expr: '$record.message matches "^<[^>]+>"'
         output: syslog_beginning_parser
-      - expr: '$record.message matches "^[\\d]+:\\s+\\w+\\s+\\d+\\s+\\d+:\\d+:\\d+\\s+\\w+:"'
+      - expr: '$record.message matches "^[\\d]+:\\s+(\\*)?\\w+\\s+\\d+\\s+\\d+:\\d+:\\d+\\s+\\w+:"'
         output: catalyst_parser
 
   - id: syslog_beginning_parser
@@ -55,8 +55,9 @@ pipeline:
     output: catalyst_parser
 
   - id: catalyst_parser
+    if: '$record.message matches "^[\\d]+:\\s+(\\*)?\\w+\\s+\\d+\\s+\\d+:\\d+:\\d+\\s+\\w+:"'
     type: regex_parser
-    regex: '^(?P<sequence_number>\d+):\s+(?P<timestamp>\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\w{3}):\s+%(?P<facility_text>[^-]+)-(?P<severity>\d+)-(?P<mnemonic>[^:]+):\s*(?P<message>.*)'
+    regex: '^(?P<sequence_number>\d+):\s+(\*)?(?P<timestamp>\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\w{3}):\s+%(?P<facility_text>[^-]+)-(?P<severity>\d+)-(?P<mnemonic>[^:]+):\s*(?P<message>.*)'
     parse_from: message
     timestamp:
       parse_from: $record.timestamp


### PR DESCRIPTION
In customer environment we were seeing a * in front of the timestamp which would cause the regex to fail to parse. Updated regex and routers to handle this without error.