### PR TITLE
Add additional message parser to cisco_meraki plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.88] Unreleased
 
+### Changed
+
+- `cisco_meraki`: Add additonal message parser ([PR376](https://github.com/observIQ/stanza-plugins/pull/376))
+
 ### Fixed
 
 - `haproxy`: Fixed typo with field name `query_parameter` ([PR368](https://github.com/observIQ/stanza-plugins/pull/368))

--- a/plugins/cisco_meraki.yaml
+++ b/plugins/cisco_meraki.yaml
@@ -1,5 +1,5 @@
 # Plugin Info
-version: 0.0.9
+version: 0.0.10
 title: Cisco Meraki
 description: Log parser for Cisco Meraki
 min_stanza_version: 1.2.7
@@ -85,6 +85,8 @@ pipeline:
         output: message_2_parser
       - expr: '$record.message matches "^src=.*\\s*dst=.*\\s*mac=.*\\s*user=.*\\s*"'
         output: message_3_parser
+      - expr: '$record.message matches "^src=.*\\s*dst=.*\\s*mac=.*\\s*"'
+        output: message_4_parser
 
   - id: message_1_parser
     type: regex_parser
@@ -102,6 +104,12 @@ pipeline:
     type: regex_parser
     parse_from: $record.message
     regex: '^src=(?P<src>[^\s]*)\s*dst=(?P<dst>[^\s]*)\s*mac=(?P<mac>[^\s]*)\s*user=(?P<user>[^\s]*)\s*(?P<message>[\s\S]*)'
+    output: {{.output}}
+
+  - id: message_4_parser
+    type: regex_parser
+    parse_from: $record.message
+    regex: '^src=(?P<src>[^\s]*)\s*dst=(?P<dst>[^\s]*)\s*mac=(?P<mac>[^\s]*)\s*(?P<message>[\s\S]*)'
     output: {{.output}}
 
   - id: catch_all_parser


### PR DESCRIPTION
Added additional parser for the following log message format
```
<134>1 1623335469.640442954 SC_CORP_FW_01 flows src=192.168.128.74:54191 dst=127.0.0.1:443 mac=00:00:00:00:00:00 request: UNKNOWN https://test.test.test/...
```
With output of:
``` json
{
  "timestamp": "2021-06-10T10:31:09.640442954-04:00",
  "severity": 30,
  "severity_text": "134",
  "labels": {
    "log_type": "cisco_meraki",
    "net.host.ip": "::",
    "net.host.port": "5140",
    "net.peer.ip": "127.0.0.1",
    "net.peer.port": "63373",
    "net.transport": "IP.UDP",
    "plugin_id": "cisco_meraki"
  },
  "record": {
    "app_name": "flows",
    "dst": "127.0.0.1:443",
    "hostname": "SC_CORP_FW_01",
    "mac": "00:00:00:00:00:00",
    "message": "request: UNKNOWN https://test.test.test/...",
    "src": "192.168.128.74:54191",
    "version": "1"
  }
}
```
This command
```
nc -w2 -u localhost 5140 <<< '<134>1 1623335469.640442954 SC_CORP_FW_01 flows src=192.168.128.74:54191 dst=127.0.0.1:443 mac=00:00:00:00:00:00 request: UNKNOWN https://test.test.test/...'
```