### PR TITLE
Filter out agent container logs in k8s

### DIFF
--- a/plugins/kubernetes.yaml
+++ b/plugins/kubernetes.yaml
@@ -47,7 +47,7 @@ pipeline:
   # Filter out agent logs. Check if file_name field starts with stanza or bindplane-agent.
   - id: filename_filter
     type: filter
-    expr: '$attributes["file.name"] != nil and ($attributes["file.name"] contains "stanza" or $attributes["file.name"] contains "bindplane-agent")'
+    expr: '$attributes["file.name"] != nil and ($attributes["file.name"] contains "stanza" or $attributes["file.name"] contains "bindplane-agent" or $attributes["file.name"] contains "observiq-agent")'
 
   # Initial log entry should be safe to parse as JSON
   - id: container_json_parser

--- a/plugins/kubernetes_container.yaml
+++ b/plugins/kubernetes_container.yaml
@@ -53,6 +53,7 @@ pipeline:
       - '/var/log/containers/{{ $pod_name }}-*_{{ $container_name }}-*.log'
     exclude:
       - '/var/log/containers/kube*'
+      - '/var/log/containers/observiq-agent*' # Ignore agent container logs
     # {{ range $index, $element := .exclude }}
       - {{ $element }}
     # {{ end }}


### PR DESCRIPTION
Filter out logs from agent containers so that agent containers can log to stdout without causing a feedback loop.