### PR TITLE
Fix w3c quote support

### DIFF
--- a/plugins/w3c.yaml
+++ b/plugins/w3c.yaml
@@ -2,7 +2,7 @@
 version: 0.0.4
 title: W3C
 description: File Input W3C Parser
-min_stanza_version: 1.2.0
+min_stanza_version: 1.2.12
 parameters:
   - name: file_log_path
     label: File Path


### PR DESCRIPTION
- Adds the new lazy_quotes parameter to the w3c plugin. This will add support for quoted fields and remove unnecessary operators.