### PR TITLE
Mongodb Remove Log Format

### DIFF
--- a/plugins/mongodb.yaml
+++ b/plugins/mongodb.yaml
@@ -1,4 +1,4 @@
-version: 0.0.10
+version: 0.0.11
 title: MongoDB
 description: Log parser for MongoDB
 supported_platforms:
@@ -27,7 +27,6 @@ parameters:
     description: The pod name (without the unique identifier on the end)
     type: string
     default: 'mongodb'
-    required: true
     relevant_if:
       source:
         equals: kubernetes
@@ -66,8 +65,7 @@ parameters:
 # {{$cluster_name := default "" .cluster_name}}
 # {{$pod_name := default "mongodb-*" .pod_name}}
 # {{$container_name := default "*" .container_name}}
-# {{$log_path := default "/var/log/mongodb/mongodb.log*" .log_path}}
-# {{$mongodb_json_log_format := default false .mongodb_json_log_format}}
+# {{$log_path := default "/var/log/mongodb/mongod*.log" .log_path}}
 # {{$start_at := default "end" .start_at}}
 
 # Pipeline Template
@@ -80,11 +78,7 @@ pipeline:
     cluster_name: '{{ $cluster_name }}'
     start_at: '{{ $start_at }}'
     enable_nested_json_parser: false
-    # {{ if $mongodb_json_log_format }}
-    output: json_parser
-    # {{ else }}
-    output: regex_parser
-    # {{ end }}
+    output: input_router
   # {{ end }}
 
 
@@ -96,14 +90,17 @@ pipeline:
     exclude:
       - '{{ $log_path }}*.gz'
     start_at: '{{ $start_at }}'
-    # {{ if $mongodb_json_log_format }}
-    output: json_parser
-    # {{ else }}
-    output: regex_parser
-    # {{ end }}
+    output: input_router
   # {{ end }}
 
-  - id: regex_parser
+  - id: input_router
+    type: router
+    default: legacy_parser
+    routes:
+      - expr: '$record matches "^{.*}$|^{.*}\\n$"'
+        output: 4_4_parser
+
+  - id: legacy_parser
     type: regex_parser
     regex: '^(?P<timestamp>\S+)\s+(?P<severity>\w+)\s+(?P<component>[\w-]+)\s+\[(?P<context>\S+)\]\s+(?P<message>.*)$'
     timestamp:
@@ -126,7 +123,7 @@ pipeline:
           - D5
     output: add_plugin_id
 
-  - id: json_parser
+  - id: 4_4_parser
     type: json_parser
     parse_from: $record
     timestamp:

--- a/test/configs/mongodb/invalid/invalid_log_path.yaml
+++ b/test/configs/mongodb/invalid/invalid_log_path.yaml
@@ -1,0 +1,5 @@
+# mongodb from kubernetes, default values
+pipeline:
+- type: mongodb
+  source: file
+  log_path: 12

--- a/test/configs/mongodb/valid/full_from_file.yaml
+++ b/test/configs/mongodb/valid/full_from_file.yaml
@@ -1,0 +1,6 @@
+# nginx from file, default values
+pipeline:
+- type: mongodb
+  source: file
+  log_path: "/var/log/mongodb/mongod.log"
+  start_at: beginning

--- a/test/configs/mongodb/valid/minimal_from_file.yaml
+++ b/test/configs/mongodb/valid/minimal_from_file.yaml
@@ -1,0 +1,5 @@
+# mongodb from kubernetes, default values
+pipeline:
+- type: mongodb
+  source: file
+  log_path: "/var/log/mongodb/mongod.log"

--- a/test/configs/mongodb/valid/minimal_from_kubernetes.yaml
+++ b/test/configs/mongodb/valid/minimal_from_kubernetes.yaml
@@ -1,0 +1,4 @@
+# mongodb from kubernetes, default values
+pipeline:
+- type: mongodb
+  source: kubernetes

--- a/test/configs/mongodb/valid/minimal_with_unused_parameter.yaml
+++ b/test/configs/mongodb/valid/minimal_with_unused_parameter.yaml
@@ -1,0 +1,10 @@
+# in v0.0.11 of the mongodb plugin we removed this parameter
+# `mongodb_json_log_format` we must ensure that stanza will work
+# even with extra plugin parameters
+# nginx from file, default values
+pipeline:
+- type: mongodb
+  source: file
+  log_path: "/var/log/mongodb/mongod.log"
+  start_at: beginning
+  mongodb_json_log_format: false


### PR DESCRIPTION
Removing this parameter as we can figure out the types of logs being ingested and then route to correct parsers. This is in an effort to reduce configuration bloat.


Example JSON json output (4.4+ mongo):
```json
{
"timestamp":"2021-12-08T15:35:14.095Z",
"severity":20,
"severity_text":"D4",
"labels":{
  "file_name":"mongod.log",
  "log_type":"mongodb",
  "plugin_id":"mongodb"
},
"record":{"component":"STORAGE","context":"JournalFlusher","id":22419,"message":"flushed journal"}}
```

Example Regex parsed output (<4.4 mongo):
```json
{"timestamp":"2021-12-09T19:31:45.239Z","severity":30,"severity_text":"I","labels":{"file_name":"mongod.log","log_type":"mongodb","plugin_id":"mongodb"},"record":{"component":"NETWORK","context":"conn4","message":"end connection 127.0.0.1:47320 (0 connections now open)"}}
```