### PR TITLE
Update Postgressql to gain parity with google

### DIFF
--- a/plugins/postgresql.yaml
+++ b/plugins/postgresql.yaml
@@ -36,7 +36,7 @@ pipeline:
   - id: general_regex_parser
     type: regex_parser
     parse_from: log_entry
-    regex: '^t=(?P<time>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\s+[^\s]+)\s+p=(?P<process_id>\d*)\s+s=(?P<process_start_time>[^\.]*)\.[^\s]+\s+l=(?P<process_log_line>[^\s]*)\s+u=(?P<user_name>[^\s]*)\s+db=(?P<database>[^\s]*)\s+r=(?P<client_address>[^\s]*)\s*(LOG:\s*duration:\s*(?P<duration>[\w\.:]*)\s*ms\s*)?(?P<message>[\w\W]+)?'
+    regex: '^(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?P<tid>\d+)\](?:\s+(?P<role>\S*)@(?P<user>\S*))?\s*(?P<level>\w+):\s+(?P<message>.*)'
     timestamp:
       parse_from: time
       layout: '%F %T %Z'

--- a/plugins/postgresql.yaml
+++ b/plugins/postgresql.yaml
@@ -36,10 +36,25 @@ pipeline:
   - id: general_regex_parser
     type: regex_parser
     parse_from: log_entry
-    regex: '^(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?P<tid>\d+)\](?:\s+(?P<role>\S*)@(?P<user>\S*))?\s*(?P<level>\w+):\s+(?P<message>.*)'
+    regex: '^(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,} \w+)\s*\[(?P<tid>\d+)\](?:\s+(?P<role>\S*)@(?P<user>\S*))?\s*(?P<level>\w+):\s+(?P<message>(?:\s*duration:\s*(?P<duration>[\d\.:]*)\s*ms\s*)?.*)'
     timestamp:
       parse_from: time
       layout: '%F %T %Z'
+
+  - type: router
+    default: client_address_regex_parser
+    routes:
+      - output: client_address_regex_parser
+        expr: '$record.duration != ""'
+        labels:
+          log_type: 'postgresql.slow_query'
+
+  - id: client_address_regex_parser
+    if: '$record.user matches "[\\w\\.]*\\([\\d]*\\)"'
+    type: regex_parser
+    parse_from: $record.user
+    regex: '(?P<user>[^\(]*)\((?P<client_address_port>[^\)]*)\)'
+    output: statement_regex_parser
 
   - id: statement_regex_parser
     if: '$record.message matches "^STATEMENT:|^statement:"'

--- a/plugins/postgresql.yaml
+++ b/plugins/postgresql.yaml
@@ -26,7 +26,7 @@ pipeline:
     include:
       - {{ $postgresql_log_path }}
     multiline:
-      line_start_pattern: '^t=\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}'
+      line_start_pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3,}'
     write_to: log_entry
     start_at: {{ $start_at }}
     labels:
@@ -40,21 +40,6 @@ pipeline:
     timestamp:
       parse_from: time
       layout: '%F %T %Z'
-
-  - type: router
-    default: client_address_regex_parser
-    routes:
-      - output: client_address_regex_parser
-        expr: '$record.duration != ""'
-        labels:
-          log_type: 'postgresql.slow_query'
-
-  - id: client_address_regex_parser
-    if: '$record.client_address matches "[\\w\\.]*\\([\\d]*\\)"'
-    type: regex_parser
-    parse_from: $record.client_address
-    regex: '(?P<client_address>[^\(]*)\((?P<client_address_port>[^\)]*)\)'
-    output: statement_regex_parser
 
   - id: statement_regex_parser
     if: '$record.message matches "^STATEMENT:|^statement:"'


### PR DESCRIPTION
Example Log:
```
2022-02-17 21:07:07.829 UTC [5529] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2022-02-17 21:07:07.835 UTC [5530] LOG:  database system was shut down at 2022-02-17 21:07:07 UTC
2022-02-17 21:07:07.841 UTC [5529] LOG:  database system is ready to accept connections
```

Example output:
```
{"timestamp":"2022-02-17T21:07:07.841Z","severity":0,"labels":{"file_name":"example.log","log_type":"postgresql.general","plugin_id":"postgresql"},"record":{"level":"LOG","message":"database system is ready to accept connections","role":"","tid":"5529","user":""}}
{"timestamp":"2022-02-17T21:07:07.829Z","severity":0,"labels":{"file_name":"example.log","log_type":"postgresql.general","plugin_id":"postgresql"},"record":{"level":"LOG","message":"listening on Unix socket \"/var/run/postgresql/.s.PGSQL.5432\"","role":"","tid":"5529","user":""}}
{"timestamp":"2022-02-17T21:07:07.835Z","severity":0,"labels":{"file_name":"example.log","log_type":"postgresql.general","plugin_id":"postgresql"},"record":{"level":"LOG","message":"database system was shut down at 2022-02-17 21:07:07 UTC","role":"","tid":"5530","user":""}}
```