### PR TITLE
Update wildfly/jboss plugin to gain parity with google

### DIFF
--- a/plugins/jboss.yaml
+++ b/plugins/jboss.yaml
@@ -1,7 +1,7 @@
 # Plugin Info
 version: 0.0.4
 title: JBoss
-description: 'Log parser for JBoss. This plugin expects the following starting format: %d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t)'
+description: 'Log parser for JBoss / WildFly.
 parameters:
   - name: file_path
     label: JBoss Logs Path
@@ -17,6 +17,11 @@ parameters:
       - end
     default: end
 
+# ops agent default file paths
+# "/opt/wildfly/standalone/log/server.log"
+# "/opt/wildfly/domain/servers/*/log/server.log"
+# "/opt/wildfly/domain/log/*.log"
+
 # Set Defaults
 # {{$file_path := default "/usr/local/JBoss/EAP-*/*/log/server.log" .file_path}}
 # {{$start_at := default "end" .start_at}}
@@ -28,7 +33,7 @@ pipeline:
     include:
       - {{ $file_path }}
     multiline:
-      line_start_pattern: '^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3}\s\w+\s'
+      line_start_pattern: '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}'
     start_at: {{ $start_at }}
     labels:
       log_type: jboss
@@ -37,12 +42,12 @@ pipeline:
 
   - id: jboss_parser
     type: regex_parser
-    regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}).\d{3}\s*(?P<jboss_severity>\w+)\s*\[(?P<category>[^\]]*)\]\s*\((?P<thread>[^)]*)\)( (?P<id>[^:]*):)? (?P<message>.*)\n'
+    regex: '^(?P<time>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d{3})\s+(?P<level>\w+)(?:\s+\[(?P<source>.+?)\])?(?:\s+\((?P<thread>.+?)\))?\s+(?P<message>(?:(?P<messageCode>[\d\w]+):)?[\s\S]*)'
     timestamp:
-      parse_from: timestamp
-      layout: '%Y-%m-%d %H:%M:%S'
+      parse_from: time
+      layout: '%Y-%m-%d %H:%M:%S,%L'
     severity:
-      parse_from: jboss_severity
+      parse_from: level
       mapping:
         emergency: fatal
         warning: warn


### PR DESCRIPTION
Example log:
```log
2022-01-18 13:44:35,372 INFO  [org.wildfly.security] (ServerService Thread Pool -- 27) ELY00001: WildFly Elytron version 1.18.1.Final
```

Example output:
```json
{
    "timestamp": "2022-01-18T13:44:35.372-05:00",
    "severity": 30,
    "severity_text": "INFO",
    "labels": {
        "file_name": "wildfly.log",
        "log_type": "jboss",
        "plugin_id": "jboss"
    },
    "record": {
        "message": "ELY00001: WildFly Elytron version 1.18.1.Final\n",
        "messageCode": "ELY00001",
        "source": "org.wildfly.security",
        "thread": "ServerService Thread Pool -- 27"
    }
}
```
Example log2
```log
2022-02-03 15:38:01,506 DEBUG [org.jboss.as.config] (MSC service thread 1-1) Configured system properties:
                   [Standalone] =
                   awt.toolkit = sun.awt.X11.XToolkit
                   file.encoding = UTF-8
                   file.separator = /
```

Example output2:
```json
{
    "timestamp": "2022-02-03T15:38:01.506-05:00",
    "severity": 20,
    "severity_text": "DEBUG",
    "labels": {
        "file_name": "wildfly.log",
        "log_type": "jboss",
        "plugin_id": "jboss"
    },
    "record": {
        "message": "Configured system properties:\n                   [Standalone] =\n                   awt.toolkit = sun.awt.X11.XToolkit\n                   file.encoding = UTF-8\n                   file.separator = /\n",
        "messageCode": "",
        "source": "org.jboss.as.config",
        "thread": "MSC service thread 1-1"
    }
}
```