### PR TITLE
Update Zookeeper to gain parity with google

### DIFF
--- a/plugins/zookeeper.yaml
+++ b/plugins/zookeeper.yaml
@@ -17,6 +17,10 @@ parameters:
       - end
     default: end
 
+# Ops Agent default path
+# "/opt/zookeeper/logs/zookeeper-*.out",
+# "/var/log/zookeeper/zookeeper.log",
+
 # Set Defaults
 # {{$file_path := default "/home/kafka/kafka/logs/zookeeper.log" .file_path}}
 # {{$start_at := default "end" .start_at}}
@@ -28,19 +32,44 @@ pipeline:
     include:
       - {{ $file_path }}
     start_at: {{ $start_at }}
+    multiline:
+      line_start_pattern: '^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2},\d{3}'
     labels:
-      log_type: zookeeper
       plugin_id: {{ .id }}
-    output: zookeeper_parser
+    output: id_router
+
+  # Route based on if ID is included
+  - id: id_router
+    type: router
+    default: zookeeper_parser
+    routes:
+      # - output: zookeeper_parser
+      #   expr: $ matches '^(\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2},\\d{3})\\s/\\[myid:(?\\d+)?'
+        # expr: $ matches '^\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2},\\d{3}'
+      - output: zookeeper_parser_no_id
+        expr: $ matches '^(\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2},\\d{3})\\s-'
 
   - id: zookeeper_parser
     type: regex_parser
-    regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3} \[myid:(?P<myid>[^\]]*)\] - (?P<zookeeper_severity>[A-Z]+)\s+\[(?P<source>[^\]]+)\] - (?P<message>.*)'
-    timestamp:
-      parse_from: timestamp
-      layout: '%Y-%m-%d %H:%M:%S'
+    regex: '^(?P<time>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2},\d{3})\s\[myid:(?P<myid>\d+)?\]\s-\s(?P<level>\w+)\s+\[(?P<thread>.+):(?P<source>.+)@(?P<line>\d+)\]\s+-\s*(?P<message>[\S\s]*)'
+    time:
+      parse_from: time
+      layout: "%Y-%m-%d %H:%M:%S,%L"
     severity:
-      parse_from: zookeeper_severity
+      parse_from: level
+      mapping:
+        warning: warn
+        critical: fatal
+    output: {{.output}}
+
+  - id: zookeeper_parser_no_id
+    type: regex_parser
+    regex: '^(?P<time>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2},\d{3})\s-\s(?P<level>\w+)\s+\[(?P<thread>.+):(?P<source>.+)@(?P<line>\d+)\]\s+-\s*(?P<message>[\S\s]*)'
+    time:
+      parse_from: time
+      layout: "%Y-%m-%d %H:%M:%S,%L"
+    severity:
+      parse_from: level
       mapping:
         warning: warn
         critical: fatal


### PR DESCRIPTION
Example log **without** id:
```log
2022-01-31 17:51:45,451 - INFO  [NIOWorkerThread-3:NIOServerCnxn@514] - Processing mntr command from /0:0:0:0:0:0:0:1:50284
```

Example output **without** id:
```json
{
    "timestamp": "2022-02-22T07:37:08.097995-05:00",
    "severity": 30,
    "severity_text": "INFO",
    "labels": {
        "file_name": "zookeeper.log",
        "plugin_id": "zookeeper"
    },
    "record": {
        "line": "514",
        "message": "Processing mntr command from /0:0:0:0:0:0:0:1:50284\n",
        "source": "NIOServerCnxn",
        "thread": "NIOWorkerThread-3",
        "time": "2022-01-31 17:51:45,451"
    }
}
```

Example log **with** id:
```log
2022-01-31 17:51:45,451 [myid:1] - INFO  [NIOWorkerThread-3:NIOServerCnxn@514] - Processing mntr command from /0:0:0:0:0:0:0:1:50284
```

Example output **with** id:
```json
{
    "timestamp": "2022-02-22T07:36:38.89738-05:00",
    "severity": 30,
    "severity_text": "INFO",
    "labels": {
        "file_name": "zookeeper.log",
        "plugin_id": "zookeeper"
    },
    "record": {
        "line": "514",
        "message": "Processing mntr command from /0:0:0:0:0:0:0:1:50284\n",
        "myid": "1",
        "source": "NIOServerCnxn",
        "thread": "NIOWorkerThread-3",
        "time": "2022-01-31 17:51:45,451"
    }
}
```

Example multiline log:
```log
2022-02-01 00:46:33,626 - WARN  [SendWorker:2:QuorumCnxManager$SendWorker@1283] - Interrupted while waiting for message on queue
java.lang.InterruptedException
	at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.reportInterruptAfterWait(AbstractQueuedSynchronizer.java:2056)
	at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2133)
	at org.apache.zookeeper.util.CircularBlockingQueue.poll(CircularBlockingQueue.java:105)
	at org.apache.zookeeper.server.quorum.QuorumCnxManager.pollSendQueue(QuorumCnxManager.java:1448)
	at org.apache.zookeeper.server.quorum.QuorumCnxManager.access$900(QuorumCnxManager.java:99)
	at org.apache.zookeeper.server.quorum.QuorumCnxManager$SendWorker.run(QuorumCnxManager.java:1272)
```

Example multiline output:
```json
{
    "timestamp": "2022-02-22T07:34:43.89475-05:00",
    "severity": 50,
    "severity_text": "WARN",
    "labels": {
        "file_name": "zookeeper.log",
        "plugin_id": "zookeeper"
    },
    "record": {
        "line": "1283",
        "message": "Interrupted while waiting for message on queue\njava.lang.InterruptedException\n\tat java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.reportInterruptAfterWait(AbstractQueuedSynchronizer.java:2056)\n\tat java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2133)\n\tat org.apache.zookeeper.util.CircularBlockingQueue.poll(CircularBlockingQueue.java:105)\n\tat org.apache.zookeeper.server.quorum.QuorumCnxManager.pollSendQueue(QuorumCnxManager.java:1448)\n\tat org.apache.zookeeper.server.quorum.QuorumCnxManager.access$900(QuorumCnxManager.java:99)\n\tat org.apache.zookeeper.server.quorum.QuorumCnxManager$SendWorker.run(QuorumCnxManager.java:1272)\n",
        "source": "QuorumCnxManager$SendWorker",
        "thread": "SendWorker:2",
        "time": "2022-02-01 00:46:33,626"
    }
}
```