### PR TITLE
Update Tomcat to gain parity with Google

### DIFF
--- a/plugins/tomcat.yaml
+++ b/plugins/tomcat.yaml
@@ -37,10 +37,10 @@ parameters:
     description: The pod name (without the unique identifier on the end)
     type: string
     default: 'tomcat-*'
-    required: true
     relevant_if:
       source:
         equals: kubernetes
+    required: false
   - name: container_name
     label: Container Name
     description: The container name of the Nginx container
@@ -144,13 +144,13 @@ pipeline:
     # {{ if eq $log_format "default" }}
   - id: access_regex_parser
     type: regex_parser
-    regex: '(?P<remote_host>[^\s]+) - (?P<remote_user>[^\s]+) \[(?P<timestamp>[^\]]+)\] "(?P<method>[A-Z]+) (?P<path>[^\s]+)[^"]+" (?P<status>\d+) (?P<bytes_sent>[^\s]+)'
+    regex: '(?P<http_request_remoteIp>[^ ]*) (?P<host>[^ ]*) (?P<user>[^ ]*) \[(?P<time>[^\]]*)\] "(?P<http_request_requestMethod>\S+)(?: +(?P<http_request_requestUrl>[^\"]*?)(?: +(?P<http_request_protocol>\S+))?)?" (?P<http_request_status>[^ ]*) (?P<http_request_responseSize>[^ ]*)(?: "(?P<http_request_referer>[^\"]*)" "(?P<http_request_userAgent>[^\"]*)")?'
     timestamp:
-      parse_from: timestamp
+      parse_from: time
       layout: '%d/%b/%Y:%H:%M:%S %z'
     severity:
-      parse_from: status
-      preserve_to: status
+      parse_from: http_request_status
+      preserve_to: http_request_status
       mapping:
         info: 2xx
         notice: 3xx
@@ -162,7 +162,7 @@ pipeline:
   - id: access_json_parser
     type: json_parser
     timestamp:
-      parse_from: timestamp
+      parse_from: time
       layout: '[%d/%h/%Y:%H:%M:%S %z]'
     severity:
       parse_from: status
@@ -190,7 +190,7 @@ pipeline:
       - {{ $catalina_log_path }}
     start_at: {{ $start_at }}
     multiline:
-      line_start_pattern: '[0-9]{2}-[A-Za-z]{3}-[0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}'
+      line_start_pattern: '^\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3}'
     labels:
       log_type: 'tomcat.catalina'
       plugin_id: {{ .id }}
@@ -200,7 +200,7 @@ pipeline:
   #{{ if $enable_catalina_log }}
   - id: catalina_regex_parser
     type: regex_parser
-    regex: '(?P<timestamp>[0-9]{2}-[A-Za-z]{3}-[0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3})\s(?P<tomcat_severity>[A-Z]*)\s\[(?P<thread>[\w-]*)\]\s(?P<tc_source>[^ ]*)\s(?P<message>[\s\S]+)'
+    regex: '^(?P<timestamp>\d{2}-[A-Z]{1}[a-z]{2}-\d{4}\s\d{2}:\d{2}:\d{2}.\d{3})\s(?P<tomcat_severity>[A-Z]+)\s\[(?P<module>[^\]]+)\]\s(?P<message>(?P<source>[\w\.]+)[\S\s]+)'
     timestamp:
       parse_from: timestamp
       layout: '%d-%b-%Y %H:%M:%S.%L'


### PR DESCRIPTION
Example System Logs
```
18-Feb-2022 17:35:00.810 INFO [main] org.apache.catalina.startup.Catalina.start Server startup in [1,904] milliseconds
18-Feb-2022 17:35:58.201 INFO [Thread-3] org.apache.coyote.AbstractProtocol.pause Pausing ProtocolHandler ["http-nio-8080"]
13-Jan-2022 16:10:27.715 SEVERE [main] org.apache.catalina.core.ContainerBase.removeChild Error destroying child
org.apache.catalina.LifecycleException: An invalid Lifecycle transition was attempted ([before_destroy]) for component [StandardEngine[Catalina].StandardHost[localhost].StandardContext[/examples]] in state [STARTED]
        at org.apache.catalina.util.LifecycleBase.invalidTransition(LifecycleBase.java:430)
        at org.apache.catalina.util.LifecycleBase.destroy(LifecycleBase.java:316)
```

Example System Output
```
{"timestamp":"2022-02-18T17:35:00.81-05:00","severity":30,"severity_text":"INFO","labels":{"file_name":"example.log","log_type":"tomcat.catalina","plugin_id":"tomcat"},"record":{"message":"org.apache.catalina.startup.Catalina.start Server startup in [1,904] milliseconds\n","module":"main","source":"org.apache.catalina.startup.Catalina.start"}}
{"timestamp":"2022-02-18T17:35:58.201-05:00","severity":30,"severity_text":"INFO","labels":{"file_name":"example.log","log_type":"tomcat.catalina","plugin_id":"tomcat"},"record":{"message":"org.apache.coyote.AbstractProtocol.pause Pausing ProtocolHandler [\"http-nio-8080\"]\n","module":"Thread-3","source":"org.apache.coyote.AbstractProtocol.pause"}}
{"timestamp":"2022-01-13T16:10:27.715-05:00","severity":90,"severity_text":"SEVERE","labels":{"file_name":"example.log","log_type":"tomcat.catalina","plugin_id":"tomcat"},"record":{"message":"org.apache.catalina.core.ContainerBase.removeChild Error destroying child\norg.apache.catalina.LifecycleException: An invalid Lifecycle transition was attempted ([before_destroy]) for component [StandardEngine[Catalina].StandardHost[localhost].StandardContext[/examples]] in state [STARTED]\n        at org.apache.catalina.util.LifecycleBase.invalidTransition(LifecycleBase.java:430)\n        at org.apache.catalina.util.LifecycleBase.destroy(LifecycleBase.java:316)\n","module":"main","source":"org.apache.catalina.core.ContainerBase.removeChild"}}
```

Example Access Log 
```
127.0.0.1 - - [22/Feb/2022:13:53:46 +0000] "GET /forbidden.html HTTP/1.1" 404 732
127.0.0.1 - - [22/Feb/2022:13:53:46 +0000] "GET /forbidden.html HTTP/1.1" 404 732
```

Example Access Log Output
```
{"timestamp":"2022-02-22T13:53:46Z","severity":50,"severity_text":"404","labels":{"file_name":"example.log","log_type":"tomcat.access","plugin_id":"tomcat"},"record":{"host":"-","http_request_protocol":"HTTP/1.1","http_request_referer":"","http_request_remoteIp":"127.0.0.1","http_request_requestMethod":"GET","http_request_requestUrl":"/forbidden.html","http_request_responseSize":"732","http_request_status":"404","http_request_userAgent":"","user":"-"}}
{"timestamp":"2022-02-22T13:53:46Z","severity":50,"severity_text":"404","labels":{"file_name":"example.log","log_type":"tomcat.access","plugin_id":"tomcat"},"record":{"host":"-","http_request_protocol":"HTTP/1.1","http_request_referer":"","http_request_remoteIp":"127.0.0.1","http_request_requestMethod":"GET","http_request_requestUrl":"/forbidden.html","http_request_responseSize":"732","http_request_status":"404","http_request_userAgent":"","user":"-"}}
```

