### PR TITLE
Update RabbitMQ to gain parity with google

### DIFF
--- a/plugins/rabbitmq.yaml
+++ b/plugins/rabbitmq.yaml
@@ -28,7 +28,7 @@ pipeline:
     include:
       - {{ $daemon_log_path }}
     multiline:
-      line_start_pattern: '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3}'
+      line_start_pattern: '\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+'
     start_at: {{ $start_at }}
     labels:
       log_type: rabbitmq
@@ -37,10 +37,10 @@ pipeline:
 
   - id: rabbitmq_parser
     type: regex_parser
-    regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3}) \[(?P<rabbitmq_severity>[a-z]+)\] \<(?P<id>\d+.\d+.\d+)\> (?s)(?P<message>.+)'
+    regex: '^(?P<timestamp>\d+-\d+-\d+ \d+:\d+:\d+\.\d+\+\d+:\d+) \[(?P<severity>\w+)\] \<(?P<process_id>\d+\.\d+\.\d+)\> (?P<message>.*)'
     timestamp:
       parse_from: timestamp
-      layout: '%Y-%m-%d %H:%M:%S.%s'
+      layout: '%Y-%m-%d %H:%M:%S.%s%j'
     severity:
-      parse_from: rabbitmq_severity
+      parse_from: severity
     output: {{.output}}


### PR DESCRIPTION
example log
```log
2022-02-16 18:59:41.066793+00:00 [debug] <0.459.0> Plugins discovery: ignoring getopt, not a RabbitMQ plugin
```

example output
```json
{
    "timestamp": "2022-02-16T18:59:41.066793Z",
    "severity": 20,
    "severity_text": "debug",
    "labels": {
        "file_name": "rabbitmq.log",
        "log_type": "rabbitmq",
        "plugin_id": "rabbitmq"
    },
    "record": {
        "message": "Plugins discovery: ignoring getopt, not a RabbitMQ plugin",
        "process_id": "0.459.0"
    }
}
```

example log2
```log
2022-02-16 18:59:40.952030+00:00 [info] <0.350.0> Supervisor {local,rabbit_sup}: child 'rabbit_tcp_listener_sup_:::5673' started (<0.460.0>): {tcp_listener_sup,start_link,[{0,0,0,0,0,0,0,0},5673,ranch_tcp,[inet6,{backlog,128},{nodelay,true},{linger,{true,0}},{exit_on_close,false}],rabbit_connection_sup,[],{rabbit_networking,tcp_listener_started,[amqp,[{backlog,128},{nodelay,true},{linger,{true,0}},{exit_on_close,false}]]},{rabbit_networking,tcp_listener_stopped,[amqp,[{backlog,128},{nodelay,true},{linger,{true,0}},{exit_on_close,false}]]},10,1,"TCP listener"]}
```

example output2
```json
{
    "timestamp": "2022-02-16T18:59:40.95203Z",
    "severity": 30,
    "severity_text": "info",
    "labels": {
        "file_name": "rabbitmq.log",
        "log_type": "rabbitmq",
        "plugin_id": "rabbitmq"
    },
    "record": {
        "message": "Supervisor {local,rabbit_sup}: child 'rabbit_tcp_listener_sup_:::5673' started (\u003c0.460.0\u003e): {tcp_listener_sup,start_link,[{0,0,0,0,0,0,0,0},5673,ranch_tcp,[inet6,{backlog,128},{nodelay,true},{linger,{true,0}},{exit_on_close,false}],rabbit_connection_sup,[],{rabbit_networking,tcp_listener_started,[amqp,[{backlog,128},{nodelay,true},{linger,{true,0}},{exit_on_close,false}]]},{rabbit_networking,tcp_listener_stopped,[amqp,[{backlog,128},{nodelay,true},{linger,{true,0}},{exit_on_close,false}]]},10,1,\"TCP listener\"]}",
        "process_id": "0.350.0"
    }
}
```

example log3
```log
2022-01-31 18:01:20.441571+00:00 [error] <0.692.0> ** Connection attempt from node 'rabbit_ctl_17@keith-testing-rabbitmq' rejected. Invalid challenge reply.
```

example output3
```json
{
    "timestamp": "2022-01-31T18:01:20.441571Z",
    "severity": 60,
    "severity_text": "error",
    "labels": {
        "file_name": "rabbitmq.log",
        "log_type": "rabbitmq",
        "plugin_id": "rabbitmq"
    },
    "record": {
        "message": "** Connection attempt from node 'rabbit_ctl_17@keith-testing-rabbitmq' rejected. Invalid challenge reply.",
        "process_id": "0.692.0"
    }
}
```