### PR TITLE
Update Solr to gain parity with google 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Here is a list of the documentation pages for Stanza Plugins. If you wish to lea
 - [`postgresql`](/docs/plugins/postgresql.md)
 - [`rabbitmq`](/docs/plugins/rabbitmq.md)
 - [`redis`](/docs/plugins/redis.md)
+- [`solr`](/docs/plugins/solr.md)
 - [`syslog`](/docs/plugins/syslog.md)
 - [`tomcat`](/docs/plugins/tomcat.md)
 - [`windows_events`](/docs/plugins/windows_events.md)

--- a/docs/plugins/solr.md
+++ b/docs/plugins/solr.md
@@ -1,0 +1,63 @@
+# `solr` plugin
+
+The `solr` plugin consumes [Apache Solr](https://solr.apache.org/) log entries from the local filesystem and outputs parsed entries.
+
+## Configuration Fields
+
+| Field       | Default                     | Description           |
+|-------------|-----------------------------|-----------------------|
+| `file_path` | `"/var/solr/logs/solr.log"` | Path to solr log file |
+| `start_at` | `end` | Start reading file from 'beginning' or 'end' |                                                                                                                                                                                                                                                         |
+
+## Example usage
+
+### Configuration
+
+Using default file log paths:
+
+```yaml
+pipeline:
+- type: solr
+- type: stdout
+
+```
+
+Using non-default file parameters:
+
+```yaml
+pipeline:
+- type: solr
+  file_path: "/path/to/logs"
+- type: stdout
+
+```
+
+Input Entry
+```log
+2022-01-06 04:16:08.794 INFO  (qtp1489933928-64) [   x:gettingstarted] o.a.s.c.S.Request [gettingstarted]  webapp=/solr path=/get params={q=*:*&_=1641440398872} status=0 QTime=2
+```
+
+Output Entry
+
+```json
+{
+    "timestamp": "2022-01-06T04:16:08.794-05:00",
+    "severity": 30,
+    "severity_text": "INFO",
+    "labels": {
+        "file_name": "solr.log",
+        "log_type": "solr",
+        "plugin_id": "solr"
+    },
+    "record": {
+        "collection": "",
+        "core": "gettingstarted",
+        "exception": "",
+        "message": "[gettingstarted]  webapp=/solr path=/get params={q=*:*\u0026_=1641440398872} status=0 QTime=2",
+        "replica": "",
+        "shard": "",
+        "source": "o.a.s.c.S.Request",
+        "thread": "qtp1489933928-64"
+    }
+}
+```

--- a/docs/plugins/solr.md
+++ b/docs/plugins/solr.md
@@ -4,10 +4,10 @@ The `solr` plugin consumes [Apache Solr](https://solr.apache.org/) log entries f
 
 ## Configuration Fields
 
-| Field       | Default                     | Description           |
-|-------------|-----------------------------|-----------------------|
-| `file_path` | `"/var/solr/logs/solr.log"` | Path to solr log file |
-| `start_at` | `end` | Start reading file from 'beginning' or 'end' |                                                                                                                                                                                                                                                         |
+| Field           | Default                     | Description           |
+|-----------------|-----------------------------|-----------------------|
+| `file_log_path` | `"/var/solr/logs/solr.log"` | Path to solr log file |
+| `start_at` | `end` | Start reading file from 'beginning' or 'end' | |
 
 ## Example usage
 
@@ -27,7 +27,8 @@ Using non-default file parameters:
 ```yaml
 pipeline:
 - type: solr
-  file_path: "/path/to/logs"
+  file_log_path:
+    - "/path/to/logs"
 - type: stdout
 
 ```

--- a/plugins/solr.yaml
+++ b/plugins/solr.yaml
@@ -17,6 +17,10 @@ parameters:
       - end
     default: end
 
+# Set Defaults
+# {{$file_path := default "/var/solr/logs/solr.log" .file_path}}
+# {{$start_at := default "end" .start_at}}
+
 # Pipeline Template
 pipeline:
   - id: solr_input
@@ -34,7 +38,7 @@ pipeline:
     regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3,6})\s(?P<level>[A-z]+)\s{1,5}\((?P<thread>[^\)]+)\)\s\[c?:?(?P<collection>[^\s]*)\ss?:?(?P<shard>[^\s]*)\sr?:?(?P<replica>[^\s]*)\sx?:?(?P<core>[^\]]*)\]\s(?P<source>[^\s]+)\s(?P<message>(?:[\s\S])+)\s?=?>?(?P<exception>[\s\S]*)'
     timestamp:
       parse_from: timestamp
-      layout: '%Y-%m-%d %H:%M:%S.%j'
+      layout: '%Y-%m-%d %H:%M:%S.%L'
     severity:
       parse_from: level
       mapping:

--- a/plugins/solr.yaml
+++ b/plugins/solr.yaml
@@ -3,11 +3,12 @@ version: 0.0.1
 title: Solr
 description: Log parser for Solr
 parameters:
-  - name: file_path
+  - name: file_log_path
     label: Solr Logs Path
     description: The absolute path to the Solr logs
-    type: string
-    default: "/var/solr/logs/solr.log"
+    type: strings
+    default: 
+    - "/var/solr/logs/solr.log"
   - name: start_at
     label: Start At
     description: Start reading file from 'beginning' or 'end'
@@ -18,7 +19,6 @@ parameters:
     default: end
 
 # Set Defaults
-# {{$file_path := default "/var/solr/logs/solr.log" .file_path}}
 # {{$start_at := default "end" .start_at}}
 
 # Pipeline Template
@@ -26,7 +26,9 @@ pipeline:
   - id: solr_input
     type: file_input
     include:
-      - {{ $file_path }}
+# {{ range $i, $fp := .file_log_path  }}
+      - '{{ $fp }}'
+# {{ end }}
     start_at: {{ $start_at }}
     labels:
       log_type: solr

--- a/plugins/solr.yaml
+++ b/plugins/solr.yaml
@@ -1,0 +1,43 @@
+# Plugin Info
+version: 0.0.1
+title: Solr
+description: Log parser for Solr
+parameters:
+  - name: file_path
+    label: Solr Logs Path
+    description: The absolute path to the Solr logs
+    type: string
+    default: "/var/solr/logs/solr.log"
+  - name: start_at
+    label: Start At
+    description: Start reading file from 'beginning' or 'end'
+    type: enum
+    valid_values:
+      - beginning
+      - end
+    default: end
+
+# Pipeline Template
+pipeline:
+  - id: solr_input
+    type: file_input
+    include:
+      - {{ $file_path }}
+    start_at: {{ $start_at }}
+    labels:
+      log_type: solr
+      plugin_id: {{ .id }}
+    output: solr_parser
+
+  - id: solr_parser
+    type: regex_parser
+    regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3,6})\s(?P<level>[A-z]+)\s{1,5}\((?P<thread>[^\)]+)\)\s\[c?:?(?P<collection>[^\s]*)\ss?:?(?P<shard>[^\s]*)\sr?:?(?P<replica>[^\s]*)\sx?:?(?P<core>[^\]]*)\]\s(?P<source>[^\s]+)\s(?P<message>(?:[\s\S])+)\s?=?>?(?P<exception>[\s\S]*)'
+    timestamp:
+      parse_from: timestamp
+      layout: '%Y-%m-%d %H:%M:%S.%j'
+    severity:
+      parse_from: level
+      mapping:
+        critical: fatal
+        warning: warn
+    output: {{ .output }}


### PR DESCRIPTION
Example log

```log
2022-01-06 04:16:08.794 INFO  (qtp1489933928-64) [   x:gettingstarted] o.a.s.c.S.Request [gettingstarted]  webapp=/solr path=/get params={q=*:*&_=1641440398872} status=0 QTime=2
```

Example output
```json
{
    "timestamp": "2022-01-06T04:16:08.794-05:00",
    "severity": 30,
    "severity_text": "INFO",
    "labels": {
        "file_name": "solr.log",
        "log_type": "solr",
        "plugin_id": "solr"
    },
    "record": {
        "collection": "",
        "core": "gettingstarted",
        "exception": "",
        "message": "[gettingstarted]  webapp=/solr path=/get params={q=*:*\u0026_=1641440398872} status=0 QTime=2",
        "replica": "",
        "shard": "",
        "source": "o.a.s.c.S.Request",
        "thread": "qtp1489933928-64"
    }
}
```