### PR TITLE
Update Hbase to gain parity with google

### DIFF
--- a/plugins/hbase.yaml
+++ b/plugins/hbase.yaml
@@ -68,7 +68,7 @@ pipeline:
     include:
       - {{ $master_log_path }}
     multiline:
-      line_start_pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+|^\w+ \w+ \d{2} \d{2}:\d{2}:\d{2} \w+ \d{4}'
+      line_start_pattern: '^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6}|^\w+ \w+ \d{2} \d{2}:\d{2}:\d{2} \w+ \d{4}'
     start_at: {{ $start_at }}
     labels:
       log_type: hbase.master
@@ -77,12 +77,12 @@ pipeline:
   - id: master_standard_regex_parser
     type: regex_parser
     if:  '$record matches "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3}\\s+"'
-    regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\s+(?P<hbase_severity>[A-Z]*)\s*?\[(?P<thread>[^\]]*)\]\s(?P<hbase_source>[^:]*):\s(?P<message>(?s).*)\n'
+    regex: '^(?P<time>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6})\s(?P<level>[A-Z]+)\s{2}\[(?P<module>[^\]]+)\]\s(?P<message>(?P<source>[\w\.]+)[^\n]+)'
     timestamp:
-      parse_from: timestamp
-      layout: '%Y-%m-%d %H:%M:%S'
+      parse_from: time
+      layout: '%Y-%m-%d %H:%M:%S,%L'
     severity:
-      parse_from: hbase_severity
+      parse_from: level
       mapping:
         warning: warn
         emergency: fatal
@@ -98,7 +98,7 @@ pipeline:
     output: {{.output}}
 # {{ end }}
 
-# {{ if $enable_region_log }}
+# {{ if $enable_region_log}}
   - id: hbase_region_input
     type: file_input
     include:
@@ -113,12 +113,12 @@ pipeline:
   - id: region_standard_regex_parser
     type: regex_parser
     if:  '$record matches "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3}\\s+"'
-    regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\s+(?P<hbase_severity>[A-Z]*)\s*?\[(?P<thread>[^\]]*)\]\s(?P<hbase_source>[^:]*):\s(?P<message>(?s).*)\n'
+    regex: '^(?P<time>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\,\d{3,6})\s(?P<level>[A-Z]+)\s{2}\[(?P<module>[^\]]+)\]\s(?P<message>(?P<source>[\w\.]+)[^\n]+)'
     timestamp:
-      parse_from: timestamp
-      layout: '%Y-%m-%d %H:%M:%S'
+      parse_from: time
+      layout: '%Y-%m-%d %H:%M:%S,%L'
     severity:
-      parse_from: hbase_severity
+      parse_from: level
       mapping:
         warning: warn
         emergency: fatal


### PR DESCRIPTION
Example region server log:
```
2022-02-28 02:01:46,661 INFO  [main] util.VersionInfo: Compiled by andrewpurtell on Fri Dec 17 19:02:09 PST 2021
2022-02-28 02:01:46,661 INFO  [main] util.VersionInfo: From source with checksum b006a70aa660cae4558822abf4dbfb5488193f6cbc890b912febbf4b9a8b264b54a96fa0d32166e4d371904ad25e365dded902a03615764a3423f629a659d1c8
2022-02-28 02:01:46,917 WARN  [main] regionserver.HRegionServerCommandLine: Not starting a distinct region server because hbase.cluster.distributed is false
```

Example region server log ouput:
```
{"timestamp":"2022-02-28T02:01:46.661-05:00","severity":30,"severity_text":"INFO","labels":{"file_name":"hbase_region.log","log_type":"hbase.region","plugin_id":"hbase"},"record":{"message":"util.VersionInfo: Compiled by andrewpurtell on Fri Dec 17 19:02:09 PST 2021","module":"main","source":"util.VersionInfo"}}
{"timestamp":"2022-02-28T02:01:46.661-05:00","severity":30,"severity_text":"INFO","labels":{"file_name":"hbase_region.log","log_type":"hbase.region","plugin_id":"hbase"},"record":{"message":"util.VersionInfo: From source with checksum b006a70aa660cae4558822abf4dbfb5488193f6cbc890b912febbf4b9a8b264b54a96fa0d32166e4d371904ad25e365dded902a03615764a3423f629a659d1c8","module":"main","source":"util.VersionInfo"}}
{"timestamp":"2022-02-28T02:01:46.917-05:00","severity":50,"severity_text":"WARN","labels":{"file_name":"hbase_region.log","log_type":"hbase.region","plugin_id":"hbase"},"record":{"message":"regionserver.HRegionServerCommandLine: Not starting a distinct region server because hbase.cluster.distributed is false","module":"main","source":"regionserver.HRegionServerCommandLine"}}
```

Example Master Log:
```
2022-02-28 01:43:27,800 INFO  [hbase:16020Replication Statistics #0] regionserver.Replication: Global stats: WAL Edits Buffer Used=0B, Limit=268435456B
2022-02-28 01:43:38,259 INFO  [regionserver/hbase:16020.Chore.1] regionserver.HRegionServer: MemstoreFlusherChore requesting flush of hbase:meta,,1.1588230740 because 1588230740/info has an old edit so flush to free WALs after random delay 47378 ms
2022-02-28 01:43:38,260 INFO  [regionserver/hbase:16020.Chore.1] regionserver.HRegionServer: MemstoreFlusherChore requesting flush of hbase:namespace,,1646012312958.3cc87bbc4ba3f78d8dc214d045857049. because 3cc87bbc4ba3f78d8dc214d045857049/info has an old edit so flush to free WALs after random delay 298163 ms
```

Example Master Log Ouput:
```
{"timestamp":"2022-02-28T01:43:27.8-05:00","severity":30,"severity_text":"INFO","labels":{"file_name":"hbase_master.log","log_type":"hbase.master","plugin_id":"hbase"},"record":{"message":"regionserver.Replication: Global stats: WAL Edits Buffer Used=0B, Limit=268435456B","module":"hbase:16020Replication Statistics #0","source":"regionserver.Replication"}}
{"timestamp":"2022-02-28T01:43:38.259-05:00","severity":30,"severity_text":"INFO","labels":{"file_name":"hbase_master.log","log_type":"hbase.master","plugin_id":"hbase"},"record":{"message":"regionserver.HRegionServer: MemstoreFlusherChore requesting flush of hbase:meta,,1.1588230740 because 1588230740/info has an old edit so flush to free WALs after random delay 47378 ms","module":"regionserver/hbase:16020.Chore.1","source":"regionserver.HRegionServer"}}
{"timestamp":"2022-02-28T01:43:38.26-05:00","severity":30,"severity_text":"INFO","labels":{"file_name":"hbase_master.log","log_type":"hbase.master","plugin_id":"hbase"},"record":{"message":"regionserver.HRegionServer: MemstoreFlusherChore requesting flush of hbase:namespace,,1646012312958.3cc87bbc4ba3f78d8dc214d045857049. because 3cc87bbc4ba3f78d8dc214d045857049/info has an old edit so flush to free WALs after random delay 298163 ms","module":"regionserver/hbase:16020.Chore.1","source":"regionserver.HRegionServer"}}
```