### PR TITLE
Make tomcat pod name optional

### DIFF
--- a/plugins/tomcat.yaml
+++ b/plugins/tomcat.yaml
@@ -37,7 +37,7 @@ parameters:
     description: The pod name (without the unique identifier on the end)
     type: string
     default: 'tomcat-*'
-    required: true
+    required: false
     relevant_if:
       source:
         equals: kubernetes


### PR DESCRIPTION
The default value for pod is fine, it can be optional. This way, users outside of kubernetes will not need to specify a pod name.